### PR TITLE
Implement Workload Projection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ testbin/*
 *.swp
 *.swo
 *~
+.vscode

--- a/projector/binding.go
+++ b/projector/binding.go
@@ -18,14 +18,24 @@ package projector
 
 import (
 	"context"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
 
 	servicebindingv1alpha3 "github.com/servicebinding/service-binding-controller/apis/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	ServiceBindingRootEnv = "SERVICE_BINDING_ROOT"
+	ServiceBindingRootEnv    = "SERVICE_BINDING_ROOT"
+	Group                    = "projector.servicebinding.io"
+	VolumePrefix             = Group + "/volume-"
+	SecretAnnotationPrefix   = Group + "/secret-"
+	TypeAnnotationPrefix     = Group + "/type-"
+	ProviderAnnotationPrefix = Group + "/provider-"
 )
 
 var _ ServiceBindingProjector = (*serviceBindingProjector)(nil)
@@ -42,8 +52,8 @@ func New(mappingSource MappingSource) ServiceBindingProjector {
 	}
 }
 
-func (i *serviceBindingProjector) Project(ctx context.Context, binding *servicebindingv1alpha3.ServiceBinding, workload client.Object) error {
-	mapping, err := i.mappingSource.Lookup(ctx, workload)
+func (p *serviceBindingProjector) Project(ctx context.Context, binding *servicebindingv1alpha3.ServiceBinding, workload client.Object) error {
+	mapping, err := p.mappingSource.Lookup(ctx, workload)
 	if err != nil {
 		return err
 	}
@@ -51,14 +61,12 @@ func (i *serviceBindingProjector) Project(ctx context.Context, binding *serviceb
 	if err != nil {
 		return err
 	}
-	if err := i.project(ctx, binding, mpt); err != nil {
-		return err
-	}
+	p.project(binding, mpt)
 	return mpt.WriteToWorkload(ctx)
 }
 
-func (i *serviceBindingProjector) Unproject(ctx context.Context, binding *servicebindingv1alpha3.ServiceBinding, workload client.Object) error {
-	mapping, err := i.mappingSource.Lookup(ctx, workload)
+func (p *serviceBindingProjector) Unproject(ctx context.Context, binding *servicebindingv1alpha3.ServiceBinding, workload client.Object) error {
+	mapping, err := p.mappingSource.Lookup(ctx, workload)
 	if err != nil {
 		return err
 	}
@@ -66,45 +74,332 @@ func (i *serviceBindingProjector) Unproject(ctx context.Context, binding *servic
 	if err != nil {
 		return err
 	}
-	if err := i.unproject(ctx, binding, mpt); err != nil {
-		return err
-	}
+	p.unproject(binding, mpt)
 	return mpt.WriteToWorkload(ctx)
 }
 
-func (i *serviceBindingProjector) project(ctx context.Context, binding *servicebindingv1alpha3.ServiceBinding, mpt *metaPodTemplate) error {
+func (p *serviceBindingProjector) project(binding *servicebindingv1alpha3.ServiceBinding, mpt *metaPodTemplate) {
 	// rather than attempt to merge an existing binding, unproject it
-	if err := i.unproject(ctx, binding, mpt); err != nil {
-		return err
+	p.unproject(binding, mpt)
+
+	if p.secretName(binding) == "" {
+		// no secret to bind
+		return
+	}
+	p.projectVolume(binding, mpt)
+	for i := range mpt.Containers {
+		p.projectContainer(binding, mpt, &mpt.Containers[i])
+	}
+}
+
+func (p *serviceBindingProjector) unproject(binding *servicebindingv1alpha3.ServiceBinding, mpt *metaPodTemplate) {
+	p.unprojectVolume(binding, mpt)
+	for i := range mpt.Containers {
+		p.unprojectContainer(binding, mpt, &mpt.Containers[i])
 	}
 
-	for i := range mpt.Containers {
-		c := &mpt.Containers[i]
-		// TODO skip container if not allowed
+	// cleanup annotations
+	delete(mpt.Annotations, p.secretAnnotationName(binding))
+	delete(mpt.Annotations, p.typeAnnotationName(binding))
+	delete(mpt.Annotations, p.providerAnnotationName(binding))
+}
 
-		serviceBindingRoot := ""
-		for _, e := range c.Env {
-			if e.Name == ServiceBindingRootEnv {
-				serviceBindingRoot = e.Value
-				break
+func (p *serviceBindingProjector) projectVolume(binding *servicebindingv1alpha3.ServiceBinding, mpt *metaPodTemplate) {
+	volume := corev1.Volume{
+		Name: p.volumeName(binding),
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{
+					{
+						Secret: &corev1.SecretProjection{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: p.secretAnnotation(binding, mpt),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if binding.Spec.Type != "" {
+		volume.VolumeSource.Projected.Sources = append(volume.VolumeSource.Projected.Sources,
+			corev1.VolumeProjection{
+				DownwardAPI: &corev1.DownwardAPIProjection{
+					Items: []corev1.DownwardAPIVolumeFile{
+						{
+							Path: "type",
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: fmt.Sprintf("metadata.annotations['%s']", p.typeAnnotation(binding, mpt)),
+							},
+						},
+					},
+				},
+			},
+		)
+	}
+	if binding.Spec.Provider != "" {
+		volume.VolumeSource.Projected.Sources = append(volume.VolumeSource.Projected.Sources,
+			corev1.VolumeProjection{
+				DownwardAPI: &corev1.DownwardAPIProjection{
+					Items: []corev1.DownwardAPIVolumeFile{
+						{
+							Path: "provider",
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: fmt.Sprintf("metadata.annotations['%s']", p.providerAnnotation(binding, mpt)),
+							},
+						},
+					},
+				},
+			},
+		)
+	}
+
+	mpt.Volumes = append(mpt.Volumes, volume)
+
+	// sort all injected volumes
+	sort.SliceStable(mpt.Volumes, func(i, j int) bool {
+		in := mpt.Volumes[i].Name
+		jn := mpt.Volumes[j].Name
+		if !strings.HasPrefix(in, VolumePrefix) || !strings.HasPrefix(jn, VolumePrefix) {
+			return false
+		}
+		return in < jn
+	})
+}
+
+func (p *serviceBindingProjector) unprojectVolume(binding *servicebindingv1alpha3.ServiceBinding, mpt *metaPodTemplate) {
+	volumes := []corev1.Volume{}
+	projected := p.volumeName(binding)
+	for _, v := range mpt.Volumes {
+		if v.Name != projected {
+			volumes = append(volumes, v)
+		}
+	}
+	mpt.Volumes = volumes
+}
+
+func (p *serviceBindingProjector) projectContainer(binding *servicebindingv1alpha3.ServiceBinding, mpt *metaPodTemplate, mc *metaContainer) {
+	if !p.isContainerBindable(binding, mc) {
+		return
+	}
+	p.projectVolumeMount(binding, mc)
+	p.projectEnv(binding, mpt, mc)
+}
+
+func (p *serviceBindingProjector) unprojectContainer(binding *servicebindingv1alpha3.ServiceBinding, mpt *metaPodTemplate, mc *metaContainer) {
+	p.unprojectVolumeMount(binding, mc)
+	p.unprojectEnv(binding, mpt, mc)
+}
+
+func (p *serviceBindingProjector) projectVolumeMount(binding *servicebindingv1alpha3.ServiceBinding, mc *metaContainer) {
+	mc.VolumeMounts = append(mc.VolumeMounts, corev1.VolumeMount{
+		Name:      p.volumeName(binding),
+		ReadOnly:  true,
+		MountPath: path.Join(p.serviceBindingRoot(mc), binding.Spec.Name),
+	})
+
+	// sort all injected volume mounts
+	sort.SliceStable(mc.VolumeMounts, func(i, j int) bool {
+		in := mc.VolumeMounts[i].Name
+		jn := mc.VolumeMounts[j].Name
+		if !strings.HasPrefix(in, VolumePrefix) || !strings.HasPrefix(jn, VolumePrefix) {
+			return false
+		}
+		return in < jn
+	})
+}
+
+func (p *serviceBindingProjector) unprojectVolumeMount(binding *servicebindingv1alpha3.ServiceBinding, mc *metaContainer) {
+	mounts := []corev1.VolumeMount{}
+	projected := p.volumeName(binding)
+	for _, m := range mc.VolumeMounts {
+		if m.Name != projected {
+			mounts = append(mounts, m)
+		}
+	}
+	mc.VolumeMounts = mounts
+}
+
+func (p *serviceBindingProjector) projectEnv(binding *servicebindingv1alpha3.ServiceBinding, mpt *metaPodTemplate, mc *metaContainer) {
+	for _, e := range binding.Spec.Env {
+		if e.Key == "type" && binding.Spec.Type != "" {
+			mc.Env = append(mc.Env, corev1.EnvVar{
+				Name: e.Name,
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: fmt.Sprintf("metadata.annotations['%s']", p.typeAnnotation(binding, mpt)),
+					},
+				},
+			})
+			continue
+		}
+		if e.Key == "provider" && binding.Spec.Provider != "" {
+			mc.Env = append(mc.Env, corev1.EnvVar{
+				Name: e.Name,
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: fmt.Sprintf("metadata.annotations['%s']", p.providerAnnotation(binding, mpt)),
+					},
+				},
+			})
+			continue
+		}
+		mc.Env = append(mc.Env, corev1.EnvVar{
+			Name: e.Name,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: p.secretAnnotation(binding, mpt),
+					},
+					Key: e.Key,
+				},
+			},
+		})
+	}
+
+	// sort all injected env vars
+	secrets := p.knownProjectedSecrets(mpt)
+	sort.SliceStable(mc.Env, func(i, j int) bool {
+		ie := mc.Env[i]
+		je := mc.Env[j]
+		if !p.isProjectedEnv(ie, secrets) || !p.isProjectedEnv(je, secrets) {
+			return false
+		}
+		return ie.Name < je.Name
+	})
+}
+
+func (p *serviceBindingProjector) unprojectEnv(binding *servicebindingv1alpha3.ServiceBinding, mpt *metaPodTemplate, mc *metaContainer) {
+	if mpt.Annotations == nil {
+		return
+	}
+	env := []corev1.EnvVar{}
+	secret := mpt.Annotations[p.secretAnnotationName(binding)]
+	typeFieldPath := fmt.Sprintf("metadata.annotations['%s']", p.typeAnnotationName(binding))
+	providerFieldPath := fmt.Sprintf("metadata.annotations['%s']", p.providerAnnotationName(binding))
+	for _, e := range mc.Env {
+		// NB we do not remove the SERVICE_BINDING_ROOT env var since we don't know if someone else is depending on it
+		remove := false
+		if e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil && e.ValueFrom.SecretKeyRef.Name == secret {
+			// projected from secret
+			remove = true
+		}
+		if e.ValueFrom != nil && e.ValueFrom.FieldRef != nil {
+			if e.ValueFrom.FieldRef.FieldPath == typeFieldPath {
+				// custom type env var
+				remove = true
+			}
+			if e.ValueFrom.FieldRef.FieldPath == providerFieldPath {
+				// custom provider env var
+				remove = true
 			}
 		}
-		if serviceBindingRoot == "" {
-			serviceBindingRoot = "/bindings"
-			c.Env = append(c.Env, corev1.EnvVar{
-				Name:  ServiceBindingRootEnv,
-				Value: serviceBindingRoot,
-			})
+		if !remove {
+			env = append(env, e)
 		}
-
-		// TODO do remaining projection
 	}
-
-	return nil
+	mc.Env = env
 }
 
-func (i *serviceBindingProjector) unproject(ctx context.Context, binding *servicebindingv1alpha3.ServiceBinding, mpt *metaPodTemplate) error {
-	// TODO undo projection
+func (p *serviceBindingProjector) isContainerBindable(binding *servicebindingv1alpha3.ServiceBinding, mc *metaContainer) bool {
+	if len(binding.Spec.Workload.Containers) == 0 || mc.Name == "" {
+		return true
+	}
+	for _, name := range binding.Spec.Workload.Containers {
+		if name == mc.Name {
+			return true
+		}
+	}
+	return false
+}
 
-	return nil
+func (p *serviceBindingProjector) serviceBindingRoot(mc *metaContainer) string {
+	for _, e := range mc.Env {
+		if e.Name == ServiceBindingRootEnv {
+			return e.Value
+		}
+	}
+	// define default value
+	serviceBindingRoot := corev1.EnvVar{
+		Name:  ServiceBindingRootEnv,
+		Value: "/bindings",
+	}
+	mc.Env = append(mc.Env, serviceBindingRoot)
+	return serviceBindingRoot.Value
+}
+
+func (p *serviceBindingProjector) isProjectedEnv(e corev1.EnvVar, secrets sets.String) bool {
+	if e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil && secrets.Has(e.ValueFrom.SecretKeyRef.Name) {
+		// projected from secret
+		return true
+	}
+	if e.ValueFrom != nil && e.ValueFrom.FieldRef != nil && strings.HasPrefix(e.ValueFrom.FieldRef.FieldPath, fmt.Sprintf("metadata.annotations['%s", Group)) {
+		// projected custom type or annotation
+		return true
+	}
+	return false
+}
+
+func (p *serviceBindingProjector) knownProjectedSecrets(mpt *metaPodTemplate) sets.String {
+	secrets := sets.NewString()
+	for k, v := range mpt.Annotations {
+		if strings.HasPrefix(k, SecretAnnotationPrefix) {
+			secrets.Insert(v)
+		}
+	}
+	return secrets
+}
+
+func (p *serviceBindingProjector) secretName(binding *servicebindingv1alpha3.ServiceBinding) string {
+	if binding.Status.Binding == nil {
+		return ""
+	}
+	return binding.Status.Binding.Name
+}
+
+func (p *serviceBindingProjector) secretAnnotation(binding *servicebindingv1alpha3.ServiceBinding, mpt *metaPodTemplate) string {
+	key := p.secretAnnotationName(binding)
+	secret := p.secretName(binding)
+	if secret == "" {
+		return ""
+	}
+	if mpt.Annotations == nil {
+		mpt.Annotations = map[string]string{}
+	}
+	mpt.Annotations[key] = secret
+	return secret
+}
+
+func (p *serviceBindingProjector) secretAnnotationName(binding *servicebindingv1alpha3.ServiceBinding) string {
+	return fmt.Sprintf("%s%s", SecretAnnotationPrefix, binding.UID)
+}
+
+func (p *serviceBindingProjector) volumeName(binding *servicebindingv1alpha3.ServiceBinding) string {
+	return fmt.Sprintf("%s%s", VolumePrefix, binding.UID)
+}
+
+func (p *serviceBindingProjector) typeAnnotation(binding *servicebindingv1alpha3.ServiceBinding, mpt *metaPodTemplate) string {
+	key := p.typeAnnotationName(binding)
+	if mpt.Annotations == nil {
+		mpt.Annotations = map[string]string{}
+	}
+	mpt.Annotations[key] = binding.Spec.Type
+	return key
+}
+
+func (p *serviceBindingProjector) typeAnnotationName(binding *servicebindingv1alpha3.ServiceBinding) string {
+	return fmt.Sprintf("%s%s", TypeAnnotationPrefix, binding.UID)
+}
+
+func (p *serviceBindingProjector) providerAnnotation(binding *servicebindingv1alpha3.ServiceBinding, mpt *metaPodTemplate) string {
+	key := p.providerAnnotationName(binding)
+	if mpt.Annotations == nil {
+		mpt.Annotations = map[string]string{}
+	}
+	mpt.Annotations[key] = binding.Spec.Provider
+	return key
+}
+
+func (p *serviceBindingProjector) providerAnnotationName(binding *servicebindingv1alpha3.ServiceBinding) string {
+	return fmt.Sprintf("%s%s", ProviderAnnotationPrefix, binding.UID)
 }

--- a/projector/binding.go
+++ b/projector/binding.go
@@ -323,11 +323,11 @@ func (p *serviceBindingProjector) unprojectEnv(binding *servicebindingv1alpha3.S
 }
 
 func (p *serviceBindingProjector) isContainerBindable(binding *servicebindingv1alpha3.ServiceBinding, mc *metaContainer) bool {
-	if len(binding.Spec.Workload.Containers) == 0 || !mc.NameWasMapped() {
+	if len(binding.Spec.Workload.Containers) == 0 || mc.Name == nil {
 		return true
 	}
 	for _, name := range binding.Spec.Workload.Containers {
-		if name == mc.Name {
+		if name == *mc.Name {
 			return true
 		}
 	}

--- a/projector/binding.go
+++ b/projector/binding.go
@@ -32,7 +32,7 @@ import (
 const (
 	ServiceBindingRootEnv    = "SERVICE_BINDING_ROOT"
 	Group                    = "projector.servicebinding.io"
-	VolumePrefix             = Group + "/volume-"
+	VolumePrefix             = "servicebinding-"
 	SecretAnnotationPrefix   = Group + "/secret-"
 	TypeAnnotationPrefix     = Group + "/type-"
 	ProviderAnnotationPrefix = Group + "/provider-"
@@ -270,9 +270,6 @@ func (p *serviceBindingProjector) projectEnv(binding *servicebindingv1alpha3.Ser
 }
 
 func (p *serviceBindingProjector) unprojectEnv(binding *servicebindingv1alpha3.ServiceBinding, mpt *metaPodTemplate, mc *metaContainer) {
-	if mpt.Annotations == nil {
-		return
-	}
 	env := []corev1.EnvVar{}
 	secret := mpt.Annotations[p.secretAnnotationName(binding)]
 	typeFieldPath := fmt.Sprintf("metadata.annotations['%s']", p.typeAnnotationName(binding))
@@ -302,7 +299,7 @@ func (p *serviceBindingProjector) unprojectEnv(binding *servicebindingv1alpha3.S
 }
 
 func (p *serviceBindingProjector) isContainerBindable(binding *servicebindingv1alpha3.ServiceBinding, mc *metaContainer) bool {
-	if len(binding.Spec.Workload.Containers) == 0 || mc.Name == "" {
+	if len(binding.Spec.Workload.Containers) == 0 || !mc.NameWasMapped() {
 		return true
 	}
 	for _, name := range binding.Spec.Workload.Containers {
@@ -363,9 +360,6 @@ func (p *serviceBindingProjector) secretAnnotation(binding *servicebindingv1alph
 	if secret == "" {
 		return ""
 	}
-	if mpt.Annotations == nil {
-		mpt.Annotations = map[string]string{}
-	}
 	mpt.Annotations[key] = secret
 	return secret
 }
@@ -380,9 +374,6 @@ func (p *serviceBindingProjector) volumeName(binding *servicebindingv1alpha3.Ser
 
 func (p *serviceBindingProjector) typeAnnotation(binding *servicebindingv1alpha3.ServiceBinding, mpt *metaPodTemplate) string {
 	key := p.typeAnnotationName(binding)
-	if mpt.Annotations == nil {
-		mpt.Annotations = map[string]string{}
-	}
 	mpt.Annotations[key] = binding.Spec.Type
 	return key
 }
@@ -393,9 +384,6 @@ func (p *serviceBindingProjector) typeAnnotationName(binding *servicebindingv1al
 
 func (p *serviceBindingProjector) providerAnnotation(binding *servicebindingv1alpha3.ServiceBinding, mpt *metaPodTemplate) string {
 	key := p.providerAnnotationName(binding)
-	if mpt.Annotations == nil {
-		mpt.Annotations = map[string]string{}
-	}
 	mpt.Annotations[key] = binding.Spec.Provider
 	return key
 }

--- a/projector/binding_test.go
+++ b/projector/binding_test.go
@@ -102,7 +102,7 @@ func TestBinding(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Volumes: []corev1.Volume{
 								{
-									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									Name: "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 									VolumeSource: corev1.VolumeSource{
 										Projected: &corev1.ProjectedVolumeSource{
 											Sources: []corev1.VolumeProjection{
@@ -129,7 +129,7 @@ func TestBinding(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 											ReadOnly:  true,
 											MountPath: "/bindings/my-binding",
 										},
@@ -145,7 +145,7 @@ func TestBinding(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 											ReadOnly:  true,
 											MountPath: "/bindings/my-binding",
 										},
@@ -163,7 +163,7 @@ func TestBinding(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 											ReadOnly:  true,
 											MountPath: "/custom/path/my-binding",
 										},
@@ -179,7 +179,7 @@ func TestBinding(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 											ReadOnly:  true,
 											MountPath: "/bindings/my-binding",
 										},
@@ -267,7 +267,7 @@ func TestBinding(t *testing.T) {
 								Spec: corev1.PodSpec{
 									Volumes: []corev1.Volume{
 										{
-											Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											Name: "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 											VolumeSource: corev1.VolumeSource{
 												Projected: &corev1.ProjectedVolumeSource{
 													Sources: []corev1.VolumeProjection{
@@ -294,7 +294,7 @@ func TestBinding(t *testing.T) {
 											},
 											VolumeMounts: []corev1.VolumeMount{
 												{
-													Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+													Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 													ReadOnly:  true,
 													MountPath: "/bindings/my-binding",
 												},
@@ -310,7 +310,7 @@ func TestBinding(t *testing.T) {
 											},
 											VolumeMounts: []corev1.VolumeMount{
 												{
-													Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+													Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 													ReadOnly:  true,
 													MountPath: "/bindings/my-binding",
 												},
@@ -328,7 +328,7 @@ func TestBinding(t *testing.T) {
 											},
 											VolumeMounts: []corev1.VolumeMount{
 												{
-													Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+													Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 													ReadOnly:  true,
 													MountPath: "/custom/path/my-binding",
 												},
@@ -344,7 +344,7 @@ func TestBinding(t *testing.T) {
 											},
 											VolumeMounts: []corev1.VolumeMount{
 												{
-													Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+													Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 													ReadOnly:  true,
 													MountPath: "/bindings/my-binding",
 												},
@@ -386,7 +386,7 @@ func TestBinding(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Volumes: []corev1.Volume{
 								{
-									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									Name: "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 									VolumeSource: corev1.VolumeSource{
 										Projected: &corev1.ProjectedVolumeSource{
 											Sources: []corev1.VolumeProjection{
@@ -434,7 +434,7 @@ func TestBinding(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Volumes: []corev1.Volume{
 								{
-									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									Name: "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 									VolumeSource: corev1.VolumeSource{
 										Projected: &corev1.ProjectedVolumeSource{
 											Sources: []corev1.VolumeProjection{
@@ -460,7 +460,7 @@ func TestBinding(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 											ReadOnly:  true,
 											MountPath: "/bindings/my-binding",
 										},
@@ -482,7 +482,7 @@ func TestBinding(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Volumes: []corev1.Volume{
 								{
-									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									Name: "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 									VolumeSource: corev1.VolumeSource{
 										Projected: &corev1.ProjectedVolumeSource{
 											Sources: []corev1.VolumeProjection{
@@ -508,7 +508,7 @@ func TestBinding(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 											ReadOnly:  true,
 											MountPath: "/bindings/my-binding",
 										},
@@ -568,7 +568,7 @@ func TestBinding(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Volumes: []corev1.Volume{
 								{
-									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									Name: "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 									VolumeSource: corev1.VolumeSource{
 										Projected: &corev1.ProjectedVolumeSource{
 											Sources: []corev1.VolumeProjection{
@@ -616,7 +616,7 @@ func TestBinding(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 											ReadOnly:  true,
 											MountPath: "/bindings/my-binding",
 										},
@@ -629,7 +629,7 @@ func TestBinding(t *testing.T) {
 			},
 		},
 		{
-			name:    "update service binding env",
+			name:    "remove service binding env",
 			mapping: NewStaticMapping(&servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{}),
 			binding: &servicebindingv1alpha3.ServiceBinding{
 				ObjectMeta: metav1.ObjectMeta{
@@ -655,7 +655,7 @@ func TestBinding(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Volumes: []corev1.Volume{
 								{
-									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									Name: "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 									VolumeSource: corev1.VolumeSource{
 										Projected: &corev1.ProjectedVolumeSource{
 											Sources: []corev1.VolumeProjection{
@@ -703,7 +703,7 @@ func TestBinding(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 											ReadOnly:  true,
 											MountPath: "/bindings/my-binding",
 										},
@@ -725,7 +725,7 @@ func TestBinding(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Volumes: []corev1.Volume{
 								{
-									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									Name: "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 									VolumeSource: corev1.VolumeSource{
 										Projected: &corev1.ProjectedVolumeSource{
 											Sources: []corev1.VolumeProjection{
@@ -751,7 +751,7 @@ func TestBinding(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 											ReadOnly:  true,
 											MountPath: "/bindings/my-binding",
 										},
@@ -764,7 +764,174 @@ func TestBinding(t *testing.T) {
 			},
 		},
 		{
-			name:    "project service binding type and provider",
+			name:    "update service binding env",
+			mapping: NewStaticMapping(&servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{}),
+			binding: &servicebindingv1alpha3.ServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: uid,
+				},
+				Spec: servicebindingv1alpha3.ServiceBindingSpec{
+					Name: bindingName,
+					Env: []servicebindingv1alpha3.EnvMapping{
+						{
+							Name: "BLEEP",
+							Key:  "bleep",
+						},
+						{
+							Name: "BLOOP",
+							Key:  "bloop",
+						},
+					},
+				},
+				Status: servicebindingv1alpha3.ServiceBindingStatus{
+					Binding: &servicebindingv1alpha3.ServiceBindingSecretReference{
+						Name: secretName,
+					},
+				},
+			},
+			workload: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"projector.servicebinding.io/secret-26894874-4719-4802-8f43-8ceed127b4c2": secretName,
+							},
+						},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: secretName,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{
+										{
+											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/bindings",
+										},
+										{
+											Name: "BAR",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													Key: "bar",
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: secretName,
+													},
+												},
+											},
+										},
+										{
+											Name: "FOO",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													Key: "foo",
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: secretName,
+													},
+												},
+											},
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
+											ReadOnly:  true,
+											MountPath: "/bindings/my-binding",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"projector.servicebinding.io/secret-26894874-4719-4802-8f43-8ceed127b4c2": secretName,
+							},
+						},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: secretName,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{
+										{
+											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/bindings",
+										},
+										{
+											Name: "BLEEP",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													Key: "bleep",
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: secretName,
+													},
+												},
+											},
+										},
+										{
+											Name: "BLOOP",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													Key: "bloop",
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: secretName,
+													},
+												},
+											},
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
+											ReadOnly:  true,
+											MountPath: "/bindings/my-binding",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "project service binding type and provider for env and volume",
 			mapping: NewStaticMapping(&servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{}),
 			binding: &servicebindingv1alpha3.ServiceBinding{
 				ObjectMeta: metav1.ObjectMeta{
@@ -815,7 +982,7 @@ func TestBinding(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Volumes: []corev1.Volume{
 								{
-									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									Name: "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 									VolumeSource: corev1.VolumeSource{
 										Projected: &corev1.ProjectedVolumeSource{
 											Sources: []corev1.VolumeProjection{
@@ -881,7 +1048,7 @@ func TestBinding(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 											ReadOnly:  true,
 											MountPath: "/bindings/my-binding",
 										},
@@ -932,7 +1099,7 @@ func TestBinding(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Volumes: []corev1.Volume{
 								{
-									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									Name: "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 									VolumeSource: corev1.VolumeSource{
 										Projected: &corev1.ProjectedVolumeSource{
 											Sources: []corev1.VolumeProjection{
@@ -998,7 +1165,7 @@ func TestBinding(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 											ReadOnly:  true,
 											MountPath: "/bindings/my-binding",
 										},
@@ -1020,7 +1187,7 @@ func TestBinding(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Volumes: []corev1.Volume{
 								{
-									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									Name: "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 									VolumeSource: corev1.VolumeSource{
 										Projected: &corev1.ProjectedVolumeSource{
 											Sources: []corev1.VolumeProjection{
@@ -1068,7 +1235,7 @@ func TestBinding(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 											ReadOnly:  true,
 											MountPath: "/bindings/my-binding",
 										},
@@ -1151,6 +1318,9 @@ func TestBinding(t *testing.T) {
 								{
 									Name: "skip",
 								},
+								{
+									Name: "",
+								},
 							},
 						},
 					},
@@ -1167,7 +1337,7 @@ func TestBinding(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Volumes: []corev1.Volume{
 								{
-									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									Name: "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 									VolumeSource: corev1.VolumeSource{
 										Projected: &corev1.ProjectedVolumeSource{
 											Sources: []corev1.VolumeProjection{
@@ -1194,7 +1364,7 @@ func TestBinding(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 											ReadOnly:  true,
 											MountPath: "/bindings/my-binding",
 										},
@@ -1202,6 +1372,11 @@ func TestBinding(t *testing.T) {
 								},
 								{
 									Name:         "skip",
+									Env:          []corev1.EnvVar{},
+									VolumeMounts: []corev1.VolumeMount{},
+								},
+								{
+									Name:         "",
 									Env:          []corev1.EnvVar{},
 									VolumeMounts: []corev1.VolumeMount{},
 								},
@@ -1246,7 +1421,13 @@ func TestBinding(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Volumes: []corev1.Volume{
 								{
-									Name: "projector.servicebinding.io/volume-33333333-3333-3333-3333-333333333333",
+									Name: "preexisting",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								},
+								{
+									Name: "servicebinding-33333333-3333-3333-3333-333333333333",
 									VolumeSource: corev1.VolumeSource{
 										Projected: &corev1.ProjectedVolumeSource{
 											Sources: []corev1.VolumeProjection{
@@ -1262,7 +1443,7 @@ func TestBinding(t *testing.T) {
 									},
 								},
 								{
-									Name: "projector.servicebinding.io/volume-22222222-2222-2222-2222-222222222222",
+									Name: "servicebinding-22222222-2222-2222-2222-222222222222",
 									VolumeSource: corev1.VolumeSource{
 										Projected: &corev1.ProjectedVolumeSource{
 											Sources: []corev1.VolumeProjection{
@@ -1278,7 +1459,7 @@ func TestBinding(t *testing.T) {
 									},
 								},
 								{
-									Name: "projector.servicebinding.io/volume-11111111-1111-1111-1111-111111111111",
+									Name: "servicebinding-11111111-1111-1111-1111-111111111111",
 									VolumeSource: corev1.VolumeSource{
 										Projected: &corev1.ProjectedVolumeSource{
 											Sources: []corev1.VolumeProjection{
@@ -1322,6 +1503,10 @@ func TestBinding(t *testing.T) {
 								{
 									Env: []corev1.EnvVar{
 										{
+											Name:  "PREEXISTING",
+											Value: "env",
+										},
+										{
 											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/bindings",
 										},
@@ -1344,17 +1529,21 @@ func TestBinding(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      "projector.servicebinding.io/volume-33333333-3333-3333-3333-333333333333",
+											Name:      "preexisting",
+											MountPath: "/var/mount",
+										},
+										{
+											Name:      "servicebinding-33333333-3333-3333-3333-333333333333",
 											ReadOnly:  true,
 											MountPath: "/bindings/binding-3",
 										},
 										{
-											Name:      "projector.servicebinding.io/volume-22222222-2222-2222-2222-222222222222",
+											Name:      "servicebinding-22222222-2222-2222-2222-222222222222",
 											ReadOnly:  true,
 											MountPath: "/bindings/binding-2",
 										},
 										{
-											Name:      "projector.servicebinding.io/volume-11111111-1111-1111-1111-111111111111",
+											Name:      "servicebinding-11111111-1111-1111-1111-111111111111",
 											ReadOnly:  true,
 											MountPath: "/bindings/binding-1",
 										},
@@ -1379,7 +1568,13 @@ func TestBinding(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Volumes: []corev1.Volume{
 								{
-									Name: "projector.servicebinding.io/volume-11111111-1111-1111-1111-111111111111",
+									Name: "preexisting",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								},
+								{
+									Name: "servicebinding-11111111-1111-1111-1111-111111111111",
 									VolumeSource: corev1.VolumeSource{
 										Projected: &corev1.ProjectedVolumeSource{
 											Sources: []corev1.VolumeProjection{
@@ -1419,7 +1614,7 @@ func TestBinding(t *testing.T) {
 									},
 								},
 								{
-									Name: "projector.servicebinding.io/volume-22222222-2222-2222-2222-222222222222",
+									Name: "servicebinding-22222222-2222-2222-2222-222222222222",
 									VolumeSource: corev1.VolumeSource{
 										Projected: &corev1.ProjectedVolumeSource{
 											Sources: []corev1.VolumeProjection{
@@ -1435,7 +1630,7 @@ func TestBinding(t *testing.T) {
 									},
 								},
 								{
-									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									Name: "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 									VolumeSource: corev1.VolumeSource{
 										Projected: &corev1.ProjectedVolumeSource{
 											Sources: []corev1.VolumeProjection{
@@ -1451,7 +1646,7 @@ func TestBinding(t *testing.T) {
 									},
 								},
 								{
-									Name: "projector.servicebinding.io/volume-33333333-3333-3333-3333-333333333333",
+									Name: "servicebinding-33333333-3333-3333-3333-333333333333",
 									VolumeSource: corev1.VolumeSource{
 										Projected: &corev1.ProjectedVolumeSource{
 											Sources: []corev1.VolumeProjection{
@@ -1471,6 +1666,10 @@ func TestBinding(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Env: []corev1.EnvVar{
+										{
+											Name:  "PREEXISTING",
+											Value: "env",
+										},
 										{
 											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/bindings",
@@ -1505,22 +1704,26 @@ func TestBinding(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      "projector.servicebinding.io/volume-11111111-1111-1111-1111-111111111111",
+											Name:      "preexisting",
+											MountPath: "/var/mount",
+										},
+										{
+											Name:      "servicebinding-11111111-1111-1111-1111-111111111111",
 											ReadOnly:  true,
 											MountPath: "/bindings/binding-1",
 										},
 										{
-											Name:      "projector.servicebinding.io/volume-22222222-2222-2222-2222-222222222222",
+											Name:      "servicebinding-22222222-2222-2222-2222-222222222222",
 											ReadOnly:  true,
 											MountPath: "/bindings/binding-2",
 										},
 										{
-											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											Name:      "servicebinding-26894874-4719-4802-8f43-8ceed127b4c2",
 											ReadOnly:  true,
 											MountPath: "/bindings/my-binding",
 										},
 										{
-											Name:      "projector.servicebinding.io/volume-33333333-3333-3333-3333-333333333333",
+											Name:      "servicebinding-33333333-3333-3333-3333-333333333333",
 											ReadOnly:  true,
 											MountPath: "/bindings/binding-3",
 										},

--- a/projector/binding_test.go
+++ b/projector/binding_test.go
@@ -28,10 +28,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestBinding(t *testing.T) {
+	uid := types.UID("26894874-4719-4802-8f43-8ceed127b4c2")
+	bindingName := "my-binding"
+	secretName := "my-secret"
+
 	tests := []struct {
 		name        string
 		mapping     MappingSource
@@ -43,7 +48,19 @@ func TestBinding(t *testing.T) {
 		{
 			name:    "podspecable",
 			mapping: NewStaticMapping(&servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{}),
-			binding: &servicebindingv1alpha3.ServiceBinding{},
+			binding: &servicebindingv1alpha3.ServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: uid,
+				},
+				Spec: servicebindingv1alpha3.ServiceBindingSpec{
+					Name: bindingName,
+				},
+				Status: servicebindingv1alpha3.ServiceBindingStatus{
+					Binding: &servicebindingv1alpha3.ServiceBindingSecretReference{
+						Name: secretName,
+					},
+				},
+			},
 			workload: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
@@ -78,9 +95,29 @@ func TestBinding(t *testing.T) {
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{},
+							Annotations: map[string]string{
+								"projector.servicebinding.io/secret-26894874-4719-4802-8f43-8ceed127b4c2": secretName,
+							},
 						},
 						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: secretName,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 							InitContainers: []corev1.Container{
 								{
 									Name: "init-hello",
@@ -90,7 +127,13 @@ func TestBinding(t *testing.T) {
 											Value: "/bindings",
 										},
 									},
-									VolumeMounts: []corev1.VolumeMount{},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											ReadOnly:  true,
+											MountPath: "/bindings/my-binding",
+										},
+									},
 								},
 								{
 									Name: "init-hello-2",
@@ -100,7 +143,13 @@ func TestBinding(t *testing.T) {
 											Value: "/bindings",
 										},
 									},
-									VolumeMounts: []corev1.VolumeMount{},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											ReadOnly:  true,
+											MountPath: "/bindings/my-binding",
+										},
+									},
 								},
 							},
 							Containers: []corev1.Container{
@@ -112,7 +161,13 @@ func TestBinding(t *testing.T) {
 											Value: "/custom/path",
 										},
 									},
-									VolumeMounts: []corev1.VolumeMount{},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											ReadOnly:  true,
+											MountPath: "/custom/path/my-binding",
+										},
+									},
 								},
 								{
 									Name: "hello-2",
@@ -122,10 +177,15 @@ func TestBinding(t *testing.T) {
 											Value: "/bindings",
 										},
 									},
-									VolumeMounts: []corev1.VolumeMount{},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											ReadOnly:  true,
+											MountPath: "/bindings/my-binding",
+										},
+									},
 								},
 							},
-							Volumes: []corev1.Volume{},
 						},
 					},
 				},
@@ -147,7 +207,19 @@ func TestBinding(t *testing.T) {
 				},
 				Volumes: ".spec.jobTemplate.spec.template.spec.volumes",
 			}),
-			binding: &servicebindingv1alpha3.ServiceBinding{},
+			binding: &servicebindingv1alpha3.ServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: uid,
+				},
+				Spec: servicebindingv1alpha3.ServiceBindingSpec{
+					Name: bindingName,
+				},
+				Status: servicebindingv1alpha3.ServiceBindingStatus{
+					Binding: &servicebindingv1alpha3.ServiceBindingSecretReference{
+						Name: secretName,
+					},
+				},
+			},
 			workload: &batchv1.CronJob{
 				Spec: batchv1.CronJobSpec{
 					JobTemplate: batchv1.JobTemplateSpec{
@@ -188,9 +260,29 @@ func TestBinding(t *testing.T) {
 						Spec: batchv1.JobSpec{
 							Template: corev1.PodTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
-									Annotations: map[string]string{},
+									Annotations: map[string]string{
+										"projector.servicebinding.io/secret-26894874-4719-4802-8f43-8ceed127b4c2": "my-secret",
+									},
 								},
 								Spec: corev1.PodSpec{
+									Volumes: []corev1.Volume{
+										{
+											Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											VolumeSource: corev1.VolumeSource{
+												Projected: &corev1.ProjectedVolumeSource{
+													Sources: []corev1.VolumeProjection{
+														{
+															Secret: &corev1.SecretProjection{
+																LocalObjectReference: corev1.LocalObjectReference{
+																	Name: "my-secret",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
 									InitContainers: []corev1.Container{
 										{
 											Name: "init-hello",
@@ -200,7 +292,13 @@ func TestBinding(t *testing.T) {
 													Value: "/bindings",
 												},
 											},
-											VolumeMounts: []corev1.VolumeMount{},
+											VolumeMounts: []corev1.VolumeMount{
+												{
+													Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+													ReadOnly:  true,
+													MountPath: "/bindings/my-binding",
+												},
+											},
 										},
 										{
 											Name: "init-hello-2",
@@ -210,7 +308,13 @@ func TestBinding(t *testing.T) {
 													Value: "/bindings",
 												},
 											},
-											VolumeMounts: []corev1.VolumeMount{},
+											VolumeMounts: []corev1.VolumeMount{
+												{
+													Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+													ReadOnly:  true,
+													MountPath: "/bindings/my-binding",
+												},
+											},
 										},
 									},
 									Containers: []corev1.Container{
@@ -222,7 +326,13 @@ func TestBinding(t *testing.T) {
 													Value: "/custom/path",
 												},
 											},
-											VolumeMounts: []corev1.VolumeMount{},
+											VolumeMounts: []corev1.VolumeMount{
+												{
+													Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+													ReadOnly:  true,
+													MountPath: "/custom/path/my-binding",
+												},
+											},
 										},
 										{
 											Name: "hello-2",
@@ -232,10 +342,15 @@ func TestBinding(t *testing.T) {
 													Value: "/bindings",
 												},
 											},
-											VolumeMounts: []corev1.VolumeMount{},
+											VolumeMounts: []corev1.VolumeMount{
+												{
+													Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+													ReadOnly:  true,
+													MountPath: "/bindings/my-binding",
+												},
+											},
 										},
 									},
-									Volumes: []corev1.Volume{},
 								},
 							},
 						},
@@ -244,10 +359,637 @@ func TestBinding(t *testing.T) {
 			},
 		},
 		{
-			name:     "no containers",
-			mapping:  NewStaticMapping(&servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{}),
-			binding:  &servicebindingv1alpha3.ServiceBinding{},
+			name:    "no containers",
+			mapping: NewStaticMapping(&servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{}),
+			binding: &servicebindingv1alpha3.ServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: uid,
+				},
+				Spec: servicebindingv1alpha3.ServiceBindingSpec{
+					Name: bindingName,
+				},
+				Status: servicebindingv1alpha3.ServiceBindingStatus{
+					Binding: &servicebindingv1alpha3.ServiceBindingSecretReference{
+						Name: secretName,
+					},
+				},
+			},
 			workload: &appsv1.Deployment{},
+			expected: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"projector.servicebinding.io/secret-26894874-4719-4802-8f43-8ceed127b4c2": "my-secret",
+							},
+						},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "my-secret",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "project service binding env",
+			mapping: NewStaticMapping(&servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{}),
+			binding: &servicebindingv1alpha3.ServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: uid,
+				},
+				Spec: servicebindingv1alpha3.ServiceBindingSpec{
+					Name: bindingName,
+					Env: []servicebindingv1alpha3.EnvMapping{
+						{
+							Name: "FOO",
+							Key:  "foo",
+						},
+						{
+							Name: "BAR",
+							Key:  "bar",
+						},
+					},
+				},
+				Status: servicebindingv1alpha3.ServiceBindingStatus{
+					Binding: &servicebindingv1alpha3.ServiceBindingSecretReference{
+						Name: secretName,
+					},
+				},
+			},
+			workload: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{},
+							},
+						},
+					},
+				},
+			},
+			expected: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"projector.servicebinding.io/secret-26894874-4719-4802-8f43-8ceed127b4c2": secretName,
+							},
+						},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: secretName,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{
+										{
+											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/bindings",
+										},
+										{
+											Name: "BAR",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													Key: "bar",
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: secretName,
+													},
+												},
+											},
+										},
+										{
+											Name: "FOO",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													Key: "foo",
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: secretName,
+													},
+												},
+											},
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											ReadOnly:  true,
+											MountPath: "/bindings/my-binding",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "update service binding env",
+			mapping: NewStaticMapping(&servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{}),
+			binding: &servicebindingv1alpha3.ServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: uid,
+				},
+				Spec: servicebindingv1alpha3.ServiceBindingSpec{
+					Name: bindingName,
+				},
+				Status: servicebindingv1alpha3.ServiceBindingStatus{
+					Binding: &servicebindingv1alpha3.ServiceBindingSecretReference{
+						Name: secretName,
+					},
+				},
+			},
+			workload: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"projector.servicebinding.io/secret-26894874-4719-4802-8f43-8ceed127b4c2": secretName,
+							},
+						},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: secretName,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{
+										{
+											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/bindings",
+										},
+										{
+											Name: "BAR",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													Key: "bar",
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: secretName,
+													},
+												},
+											},
+										},
+										{
+											Name: "FOO",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													Key: "foo",
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: secretName,
+													},
+												},
+											},
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											ReadOnly:  true,
+											MountPath: "/bindings/my-binding",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"projector.servicebinding.io/secret-26894874-4719-4802-8f43-8ceed127b4c2": secretName,
+							},
+						},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: secretName,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{
+										{
+											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/bindings",
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											ReadOnly:  true,
+											MountPath: "/bindings/my-binding",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "project service binding type and provider",
+			mapping: NewStaticMapping(&servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{}),
+			binding: &servicebindingv1alpha3.ServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: uid,
+				},
+				Spec: servicebindingv1alpha3.ServiceBindingSpec{
+					Name:     bindingName,
+					Type:     "my-type",
+					Provider: "my-provider",
+					Env: []servicebindingv1alpha3.EnvMapping{
+						{
+							Name: "TYPE",
+							Key:  "type",
+						},
+						{
+							Name: "PROVIDER",
+							Key:  "provider",
+						},
+					},
+				},
+				Status: servicebindingv1alpha3.ServiceBindingStatus{
+					Binding: &servicebindingv1alpha3.ServiceBindingSecretReference{
+						Name: secretName,
+					},
+				},
+			},
+			workload: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{},
+							},
+						},
+					},
+				},
+			},
+			expected: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"projector.servicebinding.io/secret-26894874-4719-4802-8f43-8ceed127b4c2":   secretName,
+								"projector.servicebinding.io/type-26894874-4719-4802-8f43-8ceed127b4c2":     "my-type",
+								"projector.servicebinding.io/provider-26894874-4719-4802-8f43-8ceed127b4c2": "my-provider",
+							},
+						},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: secretName,
+														},
+													},
+												},
+												{
+													DownwardAPI: &corev1.DownwardAPIProjection{
+														Items: []corev1.DownwardAPIVolumeFile{
+															{
+																Path: "type",
+																FieldRef: &corev1.ObjectFieldSelector{
+																	FieldPath: "metadata.annotations['projector.servicebinding.io/type-26894874-4719-4802-8f43-8ceed127b4c2']",
+																},
+															},
+														},
+													},
+												},
+												{
+													DownwardAPI: &corev1.DownwardAPIProjection{
+														Items: []corev1.DownwardAPIVolumeFile{
+															{
+																Path: "provider",
+																FieldRef: &corev1.ObjectFieldSelector{
+																	FieldPath: "metadata.annotations['projector.servicebinding.io/provider-26894874-4719-4802-8f43-8ceed127b4c2']",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{
+										{
+											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/bindings",
+										},
+										{
+											Name: "PROVIDER",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "metadata.annotations['projector.servicebinding.io/provider-26894874-4719-4802-8f43-8ceed127b4c2']",
+												},
+											},
+										},
+										{
+											Name: "TYPE",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "metadata.annotations['projector.servicebinding.io/type-26894874-4719-4802-8f43-8ceed127b4c2']",
+												},
+											},
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											ReadOnly:  true,
+											MountPath: "/bindings/my-binding",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "update service binding type and provider",
+			mapping: NewStaticMapping(&servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{}),
+			binding: &servicebindingv1alpha3.ServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: uid,
+				},
+				Spec: servicebindingv1alpha3.ServiceBindingSpec{
+					Name: bindingName,
+					Env: []servicebindingv1alpha3.EnvMapping{
+						{
+							Name: "TYPE",
+							Key:  "type",
+						},
+						{
+							Name: "PROVIDER",
+							Key:  "provider",
+						},
+					},
+				},
+				Status: servicebindingv1alpha3.ServiceBindingStatus{
+					Binding: &servicebindingv1alpha3.ServiceBindingSecretReference{
+						Name: secretName,
+					},
+				},
+			},
+			workload: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"projector.servicebinding.io/secret-26894874-4719-4802-8f43-8ceed127b4c2":   secretName,
+								"projector.servicebinding.io/type-26894874-4719-4802-8f43-8ceed127b4c2":     "my-type",
+								"projector.servicebinding.io/provider-26894874-4719-4802-8f43-8ceed127b4c2": "my-provider",
+							},
+						},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: secretName,
+														},
+													},
+												},
+												{
+													DownwardAPI: &corev1.DownwardAPIProjection{
+														Items: []corev1.DownwardAPIVolumeFile{
+															{
+																Path: "type",
+																FieldRef: &corev1.ObjectFieldSelector{
+																	FieldPath: "metadata.annotations['projector.servicebinding.io/type-26894874-4719-4802-8f43-8ceed127b4c2']",
+																},
+															},
+														},
+													},
+												},
+												{
+													DownwardAPI: &corev1.DownwardAPIProjection{
+														Items: []corev1.DownwardAPIVolumeFile{
+															{
+																Path: "provider",
+																FieldRef: &corev1.ObjectFieldSelector{
+																	FieldPath: "metadata.annotations['projector.servicebinding.io/provider-26894874-4719-4802-8f43-8ceed127b4c2']",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{
+										{
+											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/bindings",
+										},
+										{
+											Name: "TYPE",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "metadata.annotations['projector.servicebinding.io/type-26894874-4719-4802-8f43-8ceed127b4c2']",
+												},
+											},
+										},
+										{
+											Name: "PROVIDER",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "metadata.annotations['projector.servicebinding.io/provider-26894874-4719-4802-8f43-8ceed127b4c2']",
+												},
+											},
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											ReadOnly:  true,
+											MountPath: "/bindings/my-binding",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"projector.servicebinding.io/secret-26894874-4719-4802-8f43-8ceed127b4c2": secretName,
+							},
+						},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: secretName,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{
+										{
+											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/bindings",
+										},
+										{
+											Name: "PROVIDER",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: secretName,
+													},
+													Key: "provider",
+												},
+											},
+										},
+										{
+											Name: "TYPE",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: secretName,
+													},
+													Key: "type",
+												},
+											},
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											ReadOnly:  true,
+											MountPath: "/bindings/my-binding",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "no binding if missing secret",
+			mapping: NewStaticMapping(&servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{}),
+			binding: &servicebindingv1alpha3.ServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: uid,
+				},
+				Spec: servicebindingv1alpha3.ServiceBindingSpec{
+					Name: bindingName,
+				},
+			},
+			workload: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{},
+							},
+						},
+					},
+				},
+			},
 			expected: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
@@ -256,6 +998,423 @@ func TestBinding(t *testing.T) {
 						},
 						Spec: corev1.PodSpec{
 							Volumes: []corev1.Volume{},
+							Containers: []corev1.Container{
+								{
+									Env:          []corev1.EnvVar{},
+									VolumeMounts: []corev1.VolumeMount{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "only bind to allowed containers",
+			mapping: NewStaticMapping(&servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{}),
+			binding: &servicebindingv1alpha3.ServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: uid,
+				},
+				Spec: servicebindingv1alpha3.ServiceBindingSpec{
+					Name: bindingName,
+					Workload: servicebindingv1alpha3.ServiceBindingWorkloadReference{
+						Containers: []string{"bind"},
+					},
+				},
+				Status: servicebindingv1alpha3.ServiceBindingStatus{
+					Binding: &servicebindingv1alpha3.ServiceBindingSecretReference{
+						Name: secretName,
+					},
+				},
+			},
+			workload: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "bind",
+								},
+								{
+									Name: "skip",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"projector.servicebinding.io/secret-26894874-4719-4802-8f43-8ceed127b4c2": secretName,
+							},
+						},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: secretName,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Name: "bind",
+									Env: []corev1.EnvVar{
+										{
+											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/bindings",
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											ReadOnly:  true,
+											MountPath: "/bindings/my-binding",
+										},
+									},
+								},
+								{
+									Name:         "skip",
+									Env:          []corev1.EnvVar{},
+									VolumeMounts: []corev1.VolumeMount{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "preserve other bindings",
+			mapping: NewStaticMapping(&servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{}),
+			binding: &servicebindingv1alpha3.ServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: uid,
+				},
+				Spec: servicebindingv1alpha3.ServiceBindingSpec{
+					Name: bindingName,
+					Env: []servicebindingv1alpha3.EnvMapping{
+						{
+							Name: "FOO",
+							Key:  "foo",
+						},
+					},
+				},
+				Status: servicebindingv1alpha3.ServiceBindingStatus{
+					Binding: &servicebindingv1alpha3.ServiceBindingSecretReference{
+						Name: secretName,
+					},
+				},
+			},
+			workload: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"projector.servicebinding.io/secret-11111111-1111-1111-1111-111111111111": "secret-1",
+								"projector.servicebinding.io/secret-22222222-2222-2222-2222-222222222222": "secret-2",
+								"projector.servicebinding.io/secret-33333333-3333-3333-3333-333333333333": "secret-3",
+							},
+						},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "projector.servicebinding.io/volume-33333333-3333-3333-3333-333333333333",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "secret-3",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "projector.servicebinding.io/volume-22222222-2222-2222-2222-222222222222",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "secret-2",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "projector.servicebinding.io/volume-11111111-1111-1111-1111-111111111111",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "secret-1",
+														},
+													},
+												},
+												{
+													DownwardAPI: &corev1.DownwardAPIProjection{
+														Items: []corev1.DownwardAPIVolumeFile{
+															{
+																Path: "type",
+																FieldRef: &corev1.ObjectFieldSelector{
+																	FieldPath: "metadata.annotations['projector.servicebinding.io/type-11111111-1111-1111-1111-111111111111']",
+																},
+															},
+														},
+													},
+												},
+												{
+													DownwardAPI: &corev1.DownwardAPIProjection{
+														Items: []corev1.DownwardAPIVolumeFile{
+															{
+																Path: "provider",
+																FieldRef: &corev1.ObjectFieldSelector{
+																	FieldPath: "metadata.annotations['projector.servicebinding.io/provider-11111111-1111-1111-1111-111111111111']",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{
+										{
+											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/bindings",
+										},
+										{
+											Name: "TYPE",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "metadata.annotations['projector.servicebinding.io/type-11111111-1111-1111-1111-111111111111']",
+												},
+											},
+										},
+										{
+											Name: "PROVIDER",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "metadata.annotations['projector.servicebinding.io/provider-11111111-1111-1111-1111-111111111111']",
+												},
+											},
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "projector.servicebinding.io/volume-33333333-3333-3333-3333-333333333333",
+											ReadOnly:  true,
+											MountPath: "/bindings/binding-3",
+										},
+										{
+											Name:      "projector.servicebinding.io/volume-22222222-2222-2222-2222-222222222222",
+											ReadOnly:  true,
+											MountPath: "/bindings/binding-2",
+										},
+										{
+											Name:      "projector.servicebinding.io/volume-11111111-1111-1111-1111-111111111111",
+											ReadOnly:  true,
+											MountPath: "/bindings/binding-1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"projector.servicebinding.io/secret-11111111-1111-1111-1111-111111111111": "secret-1",
+								"projector.servicebinding.io/secret-22222222-2222-2222-2222-222222222222": "secret-2",
+								"projector.servicebinding.io/secret-33333333-3333-3333-3333-333333333333": "secret-3",
+								"projector.servicebinding.io/secret-26894874-4719-4802-8f43-8ceed127b4c2": secretName,
+							},
+						},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "projector.servicebinding.io/volume-11111111-1111-1111-1111-111111111111",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "secret-1",
+														},
+													},
+												},
+												{
+													DownwardAPI: &corev1.DownwardAPIProjection{
+														Items: []corev1.DownwardAPIVolumeFile{
+															{
+																Path: "type",
+																FieldRef: &corev1.ObjectFieldSelector{
+																	FieldPath: "metadata.annotations['projector.servicebinding.io/type-11111111-1111-1111-1111-111111111111']",
+																},
+															},
+														},
+													},
+												},
+												{
+													DownwardAPI: &corev1.DownwardAPIProjection{
+														Items: []corev1.DownwardAPIVolumeFile{
+															{
+																Path: "provider",
+																FieldRef: &corev1.ObjectFieldSelector{
+																	FieldPath: "metadata.annotations['projector.servicebinding.io/provider-11111111-1111-1111-1111-111111111111']",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "projector.servicebinding.io/volume-22222222-2222-2222-2222-222222222222",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "secret-2",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: secretName,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "projector.servicebinding.io/volume-33333333-3333-3333-3333-333333333333",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "secret-3",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{
+										{
+											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/bindings",
+										},
+										{
+											Name: "FOO",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													Key: "foo",
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: "my-secret",
+													},
+												},
+											},
+										},
+										{
+											Name: "PROVIDER",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "metadata.annotations['projector.servicebinding.io/provider-11111111-1111-1111-1111-111111111111']",
+												},
+											},
+										},
+										{
+											Name: "TYPE",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "metadata.annotations['projector.servicebinding.io/type-11111111-1111-1111-1111-111111111111']",
+												},
+											},
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "projector.servicebinding.io/volume-11111111-1111-1111-1111-111111111111",
+											ReadOnly:  true,
+											MountPath: "/bindings/binding-1",
+										},
+										{
+											Name:      "projector.servicebinding.io/volume-22222222-2222-2222-2222-222222222222",
+											ReadOnly:  true,
+											MountPath: "/bindings/binding-2",
+										},
+										{
+											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											ReadOnly:  true,
+											MountPath: "/bindings/my-binding",
+										},
+										{
+											Name:      "projector.servicebinding.io/volume-33333333-3333-3333-3333-333333333333",
+											ReadOnly:  true,
+											MountPath: "/bindings/binding-3",
+										},
+									},
+								},
+							},
 						},
 					},
 				},

--- a/projector/binding_test.go
+++ b/projector/binding_test.go
@@ -408,6 +408,119 @@ func TestBinding(t *testing.T) {
 			},
 		},
 		{
+			name:    "rotate binding secret",
+			mapping: NewStaticMapping(&servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{}),
+			binding: &servicebindingv1alpha3.ServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: uid,
+				},
+				Spec: servicebindingv1alpha3.ServiceBindingSpec{
+					Name: bindingName,
+				},
+				Status: servicebindingv1alpha3.ServiceBindingStatus{
+					Binding: &servicebindingv1alpha3.ServiceBindingSecretReference{
+						Name: secretName + "-updated",
+					},
+				},
+			},
+			workload: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"projector.servicebinding.io/secret-26894874-4719-4802-8f43-8ceed127b4c2": secretName,
+							},
+						},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: secretName,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{
+										{
+											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/bindings",
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											ReadOnly:  true,
+											MountPath: "/bindings/my-binding",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"projector.servicebinding.io/secret-26894874-4719-4802-8f43-8ceed127b4c2": secretName + "-updated",
+							},
+						},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													Secret: &corev1.SecretProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: secretName + "-updated",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{
+										{
+											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/bindings",
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "projector.servicebinding.io/volume-26894874-4719-4802-8f43-8ceed127b4c2",
+											ReadOnly:  true,
+											MountPath: "/bindings/my-binding",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:    "project service binding env",
 			mapping: NewStaticMapping(&servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{}),
 			binding: &servicebindingv1alpha3.ServiceBinding{
@@ -967,7 +1080,6 @@ func TestBinding(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name:    "no binding if missing secret",
 			mapping: NewStaticMapping(&servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{}),

--- a/projector/metapodtemplate.go
+++ b/projector/metapodtemplate.go
@@ -40,9 +40,17 @@ type metaPodTemplate struct {
 
 // metaContainer contains the aspects of a Container that are appropriate for service binding.
 type metaContainer struct {
+	nameWasMapped bool
+
 	Name         string
 	Env          []corev1.EnvVar
 	VolumeMounts []corev1.VolumeMount
+}
+
+// NameWasMapped indicates that the mapping defined a JSON Path for the container name. If true and the name is empty
+// the source container was not named.
+func (mc *metaContainer) NameWasMapped() bool {
+	return mc.nameWasMapped
 }
 
 // NewMetaPodTemplate coerces the workload object into a MetaPodTemplate following the mapping definition. The
@@ -86,6 +94,7 @@ func NewMetaPodTemplate(ctx context.Context, workload runtime.Object, mapping *v
 
 			if mpt.mapping.Containers[i].Name != "" {
 				// name is optional
+				mc.nameWasMapped = true
 				if err := mpt.getAt(mpt.mapping.Containers[i].Name, cv, &mc.Name); err != nil {
 					return nil, err
 				}

--- a/projector/metapodtemplate_test.go
+++ b/projector/metapodtemplate_test.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 )
 
 func TestNewMetaPodTemplate(t *testing.T) {
@@ -95,28 +96,24 @@ func TestNewMetaPodTemplate(t *testing.T) {
 				Annotations: testAnnotations,
 				Containers: []metaContainer{
 					{
-						nameWasMapped: true,
-						Name:          "init-hello",
-						Env:           []corev1.EnvVar{},
-						VolumeMounts:  []corev1.VolumeMount{},
+						Name:         pointer.String("init-hello"),
+						Env:          []corev1.EnvVar{},
+						VolumeMounts: []corev1.VolumeMount{},
 					},
 					{
-						nameWasMapped: true,
-						Name:          "init-hello-2",
-						Env:           []corev1.EnvVar{},
-						VolumeMounts:  []corev1.VolumeMount{},
+						Name:         pointer.String("init-hello-2"),
+						Env:          []corev1.EnvVar{},
+						VolumeMounts: []corev1.VolumeMount{},
 					},
 					{
-						nameWasMapped: true,
-						Name:          "hello",
-						Env:           []corev1.EnvVar{testEnv},
-						VolumeMounts:  []corev1.VolumeMount{testVolumeMount},
+						Name:         pointer.String("hello"),
+						Env:          []corev1.EnvVar{testEnv},
+						VolumeMounts: []corev1.VolumeMount{testVolumeMount},
 					},
 					{
-						nameWasMapped: true,
-						Name:          "hello-2",
-						Env:           []corev1.EnvVar{},
-						VolumeMounts:  []corev1.VolumeMount{},
+						Name:         pointer.String("hello-2"),
+						Env:          []corev1.EnvVar{},
+						VolumeMounts: []corev1.VolumeMount{},
 					},
 				},
 				Volumes: []corev1.Volume{testVolume},
@@ -176,28 +173,24 @@ func TestNewMetaPodTemplate(t *testing.T) {
 				Annotations: testAnnotations,
 				Containers: []metaContainer{
 					{
-						nameWasMapped: true,
-						Name:          "init-hello",
-						Env:           []corev1.EnvVar{},
-						VolumeMounts:  []corev1.VolumeMount{},
+						Name:         pointer.String("init-hello"),
+						Env:          []corev1.EnvVar{},
+						VolumeMounts: []corev1.VolumeMount{},
 					},
 					{
-						nameWasMapped: true,
-						Name:          "init-hello-2",
-						Env:           []corev1.EnvVar{},
-						VolumeMounts:  []corev1.VolumeMount{},
+						Name:         pointer.String("init-hello-2"),
+						Env:          []corev1.EnvVar{},
+						VolumeMounts: []corev1.VolumeMount{},
 					},
 					{
-						nameWasMapped: true,
-						Name:          "hello",
-						Env:           []corev1.EnvVar{testEnv},
-						VolumeMounts:  []corev1.VolumeMount{testVolumeMount},
+						Name:         pointer.String("hello"),
+						Env:          []corev1.EnvVar{testEnv},
+						VolumeMounts: []corev1.VolumeMount{testVolumeMount},
 					},
 					{
-						nameWasMapped: true,
-						Name:          "hello-2",
-						Env:           []corev1.EnvVar{},
-						VolumeMounts:  []corev1.VolumeMount{},
+						Name:         pointer.String("hello-2"),
+						Env:          []corev1.EnvVar{},
+						VolumeMounts: []corev1.VolumeMount{},
 					},
 				},
 				Volumes: []corev1.Volume{testVolume},
@@ -231,10 +224,9 @@ func TestNewMetaPodTemplate(t *testing.T) {
 				Annotations: map[string]string{},
 				Containers: []metaContainer{
 					{
-						nameWasMapped: true,
-						Name:          "",
-						Env:           []corev1.EnvVar{},
-						VolumeMounts:  []corev1.VolumeMount{},
+						Name:         pointer.String(""),
+						Env:          []corev1.EnvVar{},
+						VolumeMounts: []corev1.VolumeMount{},
 					},
 				},
 				Volumes: []corev1.Volume{},
@@ -269,10 +261,9 @@ func TestNewMetaPodTemplate(t *testing.T) {
 				Annotations: map[string]string{},
 				Containers: []metaContainer{
 					{
-						nameWasMapped: false,
-						Name:          "",
-						Env:           []corev1.EnvVar{},
-						VolumeMounts:  []corev1.VolumeMount{},
+						Name:         nil,
+						Env:          []corev1.EnvVar{},
+						VolumeMounts: []corev1.VolumeMount{},
 					},
 				},
 				Volumes: []corev1.Volume{},
@@ -359,10 +350,9 @@ func TestNewMetaPodTemplate(t *testing.T) {
 				Annotations: map[string]string{},
 				Containers: []metaContainer{
 					{
-						nameWasMapped: true,
-						Name:          "",
-						Env:           []corev1.EnvVar{},
-						VolumeMounts:  []corev1.VolumeMount{},
+						Name:         pointer.String(""),
+						Env:          []corev1.EnvVar{},
+						VolumeMounts: []corev1.VolumeMount{},
 					},
 				},
 				Volumes: []corev1.Volume{},
@@ -404,7 +394,7 @@ func TestNewMetaPodTemplate(t *testing.T) {
 			if c.expectedErr {
 				return
 			}
-			if diff := cmp.Diff(c.expected, actual, cmpopts.IgnoreUnexported(metaPodTemplate{}), cmp.AllowUnexported(metaContainer{})); diff != "" {
+			if diff := cmp.Diff(c.expected, actual, cmpopts.IgnoreUnexported(metaPodTemplate{})); diff != "" {
 				t.Errorf("NewMetaPodTemplate() (-expected, +actual): %s", diff)
 			}
 		})
@@ -447,22 +437,22 @@ func TestMetaPodTemplate_WriteToWorkload(t *testing.T) {
 				Annotations: testAnnotations,
 				Containers: []metaContainer{
 					{
-						Name:         "init-hello",
+						Name:         pointer.String("init-hello"),
 						Env:          []corev1.EnvVar{},
 						VolumeMounts: []corev1.VolumeMount{},
 					},
 					{
-						Name:         "init-hello-2",
+						Name:         pointer.String("init-hello-2"),
 						Env:          []corev1.EnvVar{},
 						VolumeMounts: []corev1.VolumeMount{},
 					},
 					{
-						Name:         "hello",
+						Name:         pointer.String("hello"),
 						Env:          []corev1.EnvVar{testEnv},
 						VolumeMounts: []corev1.VolumeMount{testVolumeMount},
 					},
 					{
-						Name:         "hello-2",
+						Name:         pointer.String("hello-2"),
 						Env:          []corev1.EnvVar{},
 						VolumeMounts: []corev1.VolumeMount{},
 					},
@@ -542,22 +532,22 @@ func TestMetaPodTemplate_WriteToWorkload(t *testing.T) {
 				Annotations: testAnnotations,
 				Containers: []metaContainer{
 					{
-						Name:         "init-hello",
+						Name:         pointer.String("init-hello"),
 						Env:          []corev1.EnvVar{},
 						VolumeMounts: []corev1.VolumeMount{},
 					},
 					{
-						Name:         "init-hello-2",
+						Name:         pointer.String("init-hello-2"),
 						Env:          []corev1.EnvVar{},
 						VolumeMounts: []corev1.VolumeMount{},
 					},
 					{
-						Name:         "hello",
+						Name:         pointer.String("hello"),
 						Env:          []corev1.EnvVar{testEnv},
 						VolumeMounts: []corev1.VolumeMount{testVolumeMount},
 					},
 					{
-						Name:         "hello-2",
+						Name:         pointer.String("hello-2"),
 						Env:          []corev1.EnvVar{},
 						VolumeMounts: []corev1.VolumeMount{},
 					},
@@ -655,7 +645,7 @@ func TestMetaPodTemplate_WriteToWorkload(t *testing.T) {
 				Annotations: map[string]string{},
 				Containers: []metaContainer{
 					{
-						Name:         "",
+						Name:         pointer.String(""),
 						Env:          []corev1.EnvVar{},
 						VolumeMounts: []corev1.VolumeMount{},
 					},

--- a/projector/metapodtemplate_test.go
+++ b/projector/metapodtemplate_test.go
@@ -95,24 +95,28 @@ func TestNewMetaPodTemplate(t *testing.T) {
 				Annotations: testAnnotations,
 				Containers: []metaContainer{
 					{
-						Name:         "init-hello",
-						Env:          []corev1.EnvVar{},
-						VolumeMounts: []corev1.VolumeMount{},
+						nameWasMapped: true,
+						Name:          "init-hello",
+						Env:           []corev1.EnvVar{},
+						VolumeMounts:  []corev1.VolumeMount{},
 					},
 					{
-						Name:         "init-hello-2",
-						Env:          []corev1.EnvVar{},
-						VolumeMounts: []corev1.VolumeMount{},
+						nameWasMapped: true,
+						Name:          "init-hello-2",
+						Env:           []corev1.EnvVar{},
+						VolumeMounts:  []corev1.VolumeMount{},
 					},
 					{
-						Name:         "hello",
-						Env:          []corev1.EnvVar{testEnv},
-						VolumeMounts: []corev1.VolumeMount{testVolumeMount},
+						nameWasMapped: true,
+						Name:          "hello",
+						Env:           []corev1.EnvVar{testEnv},
+						VolumeMounts:  []corev1.VolumeMount{testVolumeMount},
 					},
 					{
-						Name:         "hello-2",
-						Env:          []corev1.EnvVar{},
-						VolumeMounts: []corev1.VolumeMount{},
+						nameWasMapped: true,
+						Name:          "hello-2",
+						Env:           []corev1.EnvVar{},
+						VolumeMounts:  []corev1.VolumeMount{},
 					},
 				},
 				Volumes: []corev1.Volume{testVolume},
@@ -172,24 +176,28 @@ func TestNewMetaPodTemplate(t *testing.T) {
 				Annotations: testAnnotations,
 				Containers: []metaContainer{
 					{
-						Name:         "init-hello",
-						Env:          []corev1.EnvVar{},
-						VolumeMounts: []corev1.VolumeMount{},
+						nameWasMapped: true,
+						Name:          "init-hello",
+						Env:           []corev1.EnvVar{},
+						VolumeMounts:  []corev1.VolumeMount{},
 					},
 					{
-						Name:         "init-hello-2",
-						Env:          []corev1.EnvVar{},
-						VolumeMounts: []corev1.VolumeMount{},
+						nameWasMapped: true,
+						Name:          "init-hello-2",
+						Env:           []corev1.EnvVar{},
+						VolumeMounts:  []corev1.VolumeMount{},
 					},
 					{
-						Name:         "hello",
-						Env:          []corev1.EnvVar{testEnv},
-						VolumeMounts: []corev1.VolumeMount{testVolumeMount},
+						nameWasMapped: true,
+						Name:          "hello",
+						Env:           []corev1.EnvVar{testEnv},
+						VolumeMounts:  []corev1.VolumeMount{testVolumeMount},
 					},
 					{
-						Name:         "hello-2",
-						Env:          []corev1.EnvVar{},
-						VolumeMounts: []corev1.VolumeMount{},
+						nameWasMapped: true,
+						Name:          "hello-2",
+						Env:           []corev1.EnvVar{},
+						VolumeMounts:  []corev1.VolumeMount{},
 					},
 				},
 				Volumes: []corev1.Volume{testVolume},
@@ -223,9 +231,48 @@ func TestNewMetaPodTemplate(t *testing.T) {
 				Annotations: map[string]string{},
 				Containers: []metaContainer{
 					{
-						Name:         "",
-						Env:          []corev1.EnvVar{},
-						VolumeMounts: []corev1.VolumeMount{},
+						nameWasMapped: true,
+						Name:          "",
+						Env:           []corev1.EnvVar{},
+						VolumeMounts:  []corev1.VolumeMount{},
+					},
+				},
+				Volumes: []corev1.Volume{},
+			},
+		},
+		{
+			name: "unmapped container name",
+			mapping: &servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{
+				Annotations: ".spec.template.metadata.annotations",
+				Containers: []servicebindingv1alpha3.ClusterWorkloadResourceMappingContainer{
+					{
+						Path: ".spec.template.spec.initContainers[*]",
+					},
+					{
+						Path: ".spec.template.spec.containers[*]",
+					},
+				},
+				Volumes: ".spec.template.spec.volumes",
+			},
+			workload: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{},
+							},
+						},
+					},
+				},
+			},
+			expected: &metaPodTemplate{
+				Annotations: map[string]string{},
+				Containers: []metaContainer{
+					{
+						nameWasMapped: false,
+						Name:          "",
+						Env:           []corev1.EnvVar{},
+						VolumeMounts:  []corev1.VolumeMount{},
 					},
 				},
 				Volumes: []corev1.Volume{},
@@ -312,9 +359,10 @@ func TestNewMetaPodTemplate(t *testing.T) {
 				Annotations: map[string]string{},
 				Containers: []metaContainer{
 					{
-						Name:         "",
-						Env:          []corev1.EnvVar{},
-						VolumeMounts: []corev1.VolumeMount{},
+						nameWasMapped: true,
+						Name:          "",
+						Env:           []corev1.EnvVar{},
+						VolumeMounts:  []corev1.VolumeMount{},
 					},
 				},
 				Volumes: []corev1.Volume{},
@@ -356,7 +404,7 @@ func TestNewMetaPodTemplate(t *testing.T) {
 			if c.expectedErr {
 				return
 			}
-			if diff := cmp.Diff(c.expected, actual, cmpopts.IgnoreUnexported(metaPodTemplate{})); diff != "" {
+			if diff := cmp.Diff(c.expected, actual, cmpopts.IgnoreUnexported(metaPodTemplate{}), cmp.AllowUnexported(metaContainer{})); diff != "" {
 				t.Errorf("NewMetaPodTemplate() (-expected, +actual): %s", diff)
 			}
 		})


### PR DESCRIPTION
Implements the full Workload Projection section of the Service Binding
Spec. The behavior is applied within the projector package meaning it is
implicitly compatible with Workload Resource Mappings.

The service binding can be projected and unprojected from the workload.
Additionally, as the ServiceBinding resource is updated, the workload is
also updated to remove the previous projection and apply the updated
projection.

Custom type and provider values are projected using the Downward API
that references an annotation on the Pod that holds the custom value.
The custom values are supported in both the volume and env vars.

In addition to annotations being used to as the source of values to the
Downward API, they are also used to link individual values to the
projected volumes, volumemounts and envvars.

The volumes, volumemounts and envvars arrays are sorted to ensure the
order ServiceBinding resources targeting the same Workload does not
matter. The order of existing values are not modified.

Signed-off-by: Scott Andrews <scott@andrews.me>