### PR TITLE
Centralize API resolution logic

### DIFF
--- a/projector/binding.go
+++ b/projector/binding.go
@@ -25,8 +25,8 @@ import (
 
 	servicebindingv1alpha3 "github.com/servicebinding/service-binding-controller/apis/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -52,7 +52,7 @@ func New(mappingSource MappingSource) ServiceBindingProjector {
 	}
 }
 
-func (p *serviceBindingProjector) Project(ctx context.Context, binding *servicebindingv1alpha3.ServiceBinding, workload client.Object) error {
+func (p *serviceBindingProjector) Project(ctx context.Context, binding *servicebindingv1alpha3.ServiceBinding, workload runtime.Object) error {
 	mapping, err := p.mappingSource.LookupMapping(ctx, workload)
 	if err != nil {
 		return err
@@ -65,7 +65,7 @@ func (p *serviceBindingProjector) Project(ctx context.Context, binding *serviceb
 	return mpt.WriteToWorkload(ctx)
 }
 
-func (p *serviceBindingProjector) Unproject(ctx context.Context, binding *servicebindingv1alpha3.ServiceBinding, workload client.Object) error {
+func (p *serviceBindingProjector) Unproject(ctx context.Context, binding *servicebindingv1alpha3.ServiceBinding, workload runtime.Object) error {
 	mapping, err := p.mappingSource.LookupMapping(ctx, workload)
 	if err != nil {
 		return err

--- a/projector/binding.go
+++ b/projector/binding.go
@@ -53,7 +53,7 @@ func New(mappingSource MappingSource) ServiceBindingProjector {
 }
 
 func (p *serviceBindingProjector) Project(ctx context.Context, binding *servicebindingv1alpha3.ServiceBinding, workload client.Object) error {
-	mapping, err := p.mappingSource.Lookup(ctx, workload)
+	mapping, err := p.mappingSource.LookupMapping(ctx, workload)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (p *serviceBindingProjector) Project(ctx context.Context, binding *serviceb
 }
 
 func (p *serviceBindingProjector) Unproject(ctx context.Context, binding *servicebindingv1alpha3.ServiceBinding, workload client.Object) error {
-	mapping, err := p.mappingSource.Lookup(ctx, workload)
+	mapping, err := p.mappingSource.LookupMapping(ctx, workload)
 	if err != nil {
 		return err
 	}

--- a/projector/binding_test.go
+++ b/projector/binding_test.go
@@ -29,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestBinding(t *testing.T) {
@@ -1990,7 +1989,7 @@ func TestBinding(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			ctx := context.TODO()
 
-			actual := c.workload.DeepCopyObject().(client.Object)
+			actual := c.workload.DeepCopyObject()
 			err := New(c.mapping).Project(ctx, c.binding, actual)
 
 			if (err != nil) != c.expectedErr {

--- a/projector/interface.go
+++ b/projector/interface.go
@@ -20,19 +20,19 @@ import (
 	"context"
 
 	servicebindingv1alpha3 "github.com/servicebinding/service-binding-controller/apis/v1alpha3"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type ServiceBindingProjector interface {
 	// Project the service into the workload as defined by the ServiceBinding.
-	Project(ctx context.Context, binding *servicebindingv1alpha3.ServiceBinding, workload client.Object) error
+	Project(ctx context.Context, binding *servicebindingv1alpha3.ServiceBinding, workload runtime.Object) error
 	// Unproject the serice from the workload as defined by the ServiceBinding.
-	Unproject(ctx context.Context, binding *servicebindingv1alpha3.ServiceBinding, workload client.Object) error
+	Unproject(ctx context.Context, binding *servicebindingv1alpha3.ServiceBinding, workload runtime.Object) error
 }
 
 type MappingSource interface {
 	// LookupMapping the mapping template for the workload. Typically a ClusterWorkloadResourceMapping is defined for the workload's
 	// fully qualified resource `{resource}.{group}`. The workload's version is either directly matched, or the wildcard version `*`
 	// mapping template is returned. If no explicit mapping is found, a mapping appropriate for a PodSpecable resource may be used.
-	LookupMapping(ctx context.Context, workload client.Object) (*servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate, error)
+	LookupMapping(ctx context.Context, workload runtime.Object) (*servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate, error)
 }

--- a/projector/mapping.go
+++ b/projector/mapping.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	servicebindingv1alpha3 "github.com/servicebinding/service-binding-controller/apis/v1alpha3"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var _ MappingSource = (*staticMapping)(nil)
@@ -40,6 +40,6 @@ func NewStaticMapping(mapping *servicebindingv1alpha3.ClusterWorkloadResourceMap
 	}
 }
 
-func (m *staticMapping) LookupMapping(ctx context.Context, workload client.Object) (*servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate, error) {
+func (m *staticMapping) LookupMapping(ctx context.Context, workload runtime.Object) (*servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate, error) {
 	return m.mapping, nil
 }

--- a/resolver/cluster.go
+++ b/resolver/cluster.go
@@ -24,13 +24,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
-// NewClusterResolver creates a new resolver backed by a controller-runtime client
-func NewClusterResolver(client client.Client) Resolver {
+// New creates a new resolver backed by a controller-runtime client
+func New(client client.Client) Resolver {
 	return &clusterResolver{
 		client: client,
 	}
@@ -40,7 +41,7 @@ type clusterResolver struct {
 	client client.Client
 }
 
-func (m *clusterResolver) LookupMapping(ctx context.Context, workload client.Object) (*servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate, error) {
+func (m *clusterResolver) LookupMapping(ctx context.Context, workload runtime.Object) (*servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate, error) {
 	gvk, err := apiutil.GVKForObject(workload, m.client.Scheme())
 	if err != nil {
 		return nil, err
@@ -96,7 +97,7 @@ func (r *clusterResolver) LookupBindingSecret(ctx context.Context, serviceRef co
 	return secretName, err
 }
 
-func (r *clusterResolver) LookupWorkload(ctx context.Context, workloadRef corev1.ObjectReference) (client.Object, error) {
+func (r *clusterResolver) LookupWorkload(ctx context.Context, workloadRef corev1.ObjectReference) (runtime.Object, error) {
 	workload := &unstructured.Unstructured{}
 	workload.SetAPIVersion(workloadRef.APIVersion)
 	workload.SetKind(workloadRef.Kind)

--- a/resolver/cluster.go
+++ b/resolver/cluster.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import (
+	"context"
+	"fmt"
+
+	servicebindingv1alpha3 "github.com/servicebinding/service-binding-controller/apis/v1alpha3"
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// NewClusterResolver creates a new resolver backed by a controller-runtime client
+func NewClusterResolver(client client.Client) Resolver {
+	return &clusterResolver{
+		client: client,
+	}
+}
+
+type clusterResolver struct {
+	client client.Client
+}
+
+func (m *clusterResolver) LookupMapping(ctx context.Context, workload client.Object) (*servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate, error) {
+	gvk, err := apiutil.GVKForObject(workload, m.client.Scheme())
+	if err != nil {
+		return nil, err
+	}
+	rm, err := m.client.RESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, err
+	}
+	wrm := &servicebindingv1alpha3.ClusterWorkloadResourceMapping{}
+	err = m.client.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s.%s", rm.Resource.Resource, rm.Resource.Group)}, wrm)
+	if err != nil {
+		if !apierrs.IsNotFound(err) {
+			return nil, err
+		}
+	}
+
+	// find version mapping
+	wildcardMapping := servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{Version: "*"}
+	var mapping *servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate
+	for _, v := range wrm.Spec.Versions {
+		switch v.Version {
+		case gvk.Version:
+			mapping = &v
+		case "*":
+			wildcardMapping = v
+		}
+	}
+	if mapping == nil {
+		// use wildcard version by default
+		mapping = &wildcardMapping
+	}
+
+	mapping = mapping.DeepCopy()
+	mapping.Default()
+
+	return mapping, nil
+}
+
+func (r *clusterResolver) LookupBindingSecret(ctx context.Context, serviceRef corev1.ObjectReference) (string, error) {
+	if serviceRef.APIVersion == "v1" && serviceRef.Kind == "Secret" {
+		// direct secret reference
+		return serviceRef.Name, nil
+	}
+	service := &unstructured.Unstructured{}
+	service.SetAPIVersion(serviceRef.APIVersion)
+	service.SetKind(serviceRef.Kind)
+	if err := r.client.Get(ctx, client.ObjectKey{Namespace: serviceRef.Namespace, Name: serviceRef.Name}, service); err != nil {
+		return "", err
+	}
+	secretName, exists, err := unstructured.NestedString(service.UnstructuredContent(), "status", "binding", "name")
+	// treat missing values as empty
+	_ = exists
+	return secretName, err
+}
+
+func (r *clusterResolver) LookupWorkload(ctx context.Context, workloadRef corev1.ObjectReference) (client.Object, error) {
+	workload := &unstructured.Unstructured{}
+	workload.SetAPIVersion(workloadRef.APIVersion)
+	workload.SetKind(workloadRef.Kind)
+	if err := r.client.Get(ctx, client.ObjectKey{Namespace: workloadRef.Namespace, Name: workloadRef.Name}, workload); err != nil {
+		return nil, err
+	}
+	return workload, nil
+}

--- a/resolver/cluster_test.go
+++ b/resolver/cluster_test.go
@@ -282,7 +282,7 @@ func TestClusterResolver_LookupMapping(t *testing.T) {
 				WithRESTMapper(restMapper).
 				WithObjects(c.givenObjects...).
 				Build()
-			resolver := resolver.NewClusterResolver(client)
+			resolver := resolver.New(client)
 
 			actual, err := resolver.LookupMapping(ctx, c.workload)
 
@@ -392,7 +392,7 @@ func TestClusterResolver_LookupBindingSecret(t *testing.T) {
 				WithScheme(scheme).
 				WithObjects(c.givenObjects...).
 				Build()
-			resolver := resolver.NewClusterResolver(client)
+			resolver := resolver.New(client)
 
 			actual, err := resolver.LookupBindingSecret(ctx, c.serviceRef)
 
@@ -515,7 +515,7 @@ func TestClusterResolver_LookupWorkload(t *testing.T) {
 				WithScheme(scheme).
 				WithObjects(c.givenObjects...).
 				Build()
-			resolver := resolver.NewClusterResolver(client)
+			resolver := resolver.New(client)
 
 			actual, err := resolver.LookupWorkload(ctx, c.serviceRef)
 

--- a/resolver/cluster_test.go
+++ b/resolver/cluster_test.go
@@ -1,0 +1,533 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	servicebindingv1alpha3 "github.com/servicebinding/service-binding-controller/apis/v1alpha3"
+	"github.com/servicebinding/service-binding-controller/resolver"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestClusterResolver_LookupMapping(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(appsv1.AddToScheme(scheme))
+	utilruntime.Must(batchv1.AddToScheme(scheme))
+	utilruntime.Must(servicebindingv1alpha3.AddToScheme(scheme))
+	restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{})
+	restMapper.Add(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, nil)
+	restMapper.Add(schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"}, nil)
+
+	tests := []struct {
+		name         string
+		givenObjects []client.Object
+		workload     client.Object
+		expected     *servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate
+		expectedErr  bool
+	}{
+		{
+			name:         "default mapping",
+			givenObjects: []client.Object{},
+			workload:     &appsv1.Deployment{},
+			expected: &servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{
+				Version:     "*",
+				Annotations: ".spec.template.metadata.annotations",
+				Containers: []servicebindingv1alpha3.ClusterWorkloadResourceMappingContainer{
+					{
+						Path:         ".spec.template.spec.initContainers[*]",
+						Name:         ".name",
+						Env:          ".env",
+						VolumeMounts: ".volumeMounts",
+					},
+					{
+						Path:         ".spec.template.spec.containers[*]",
+						Name:         ".name",
+						Env:          ".env",
+						VolumeMounts: ".volumeMounts",
+					},
+				},
+				Volumes: ".spec.template.spec.volumes",
+			},
+		},
+		{
+			name: "custom mapping",
+			givenObjects: []client.Object{
+				&servicebindingv1alpha3.ClusterWorkloadResourceMapping{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cronjobs.batch",
+					},
+					Spec: servicebindingv1alpha3.ClusterWorkloadResourceMappingSpec{
+						Versions: []servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{
+							{
+								Version:     "v1",
+								Annotations: ".spec.jobTemplate.spec.template.metadata.annotations",
+								Containers: []servicebindingv1alpha3.ClusterWorkloadResourceMappingContainer{
+									{
+										Path: ".spec.jobTemplate.spec.template.spec.initContainers[*]",
+										Name: ".name",
+									},
+									{
+										Path: ".spec.jobTemplate.spec.template.spec.containers[*]",
+										Name: ".name",
+									},
+								},
+								Volumes: ".spec.jobTemplate.spec.template.spec.volumes",
+							},
+						},
+					},
+				},
+			},
+			workload: &batchv1.CronJob{},
+			expected: &servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{
+				Version:     "v1",
+				Annotations: ".spec.jobTemplate.spec.template.metadata.annotations",
+				Containers: []servicebindingv1alpha3.ClusterWorkloadResourceMappingContainer{
+					{
+						Path:         ".spec.jobTemplate.spec.template.spec.initContainers[*]",
+						Name:         ".name",
+						Env:          ".env",
+						VolumeMounts: ".volumeMounts",
+					},
+					{
+						Path:         ".spec.jobTemplate.spec.template.spec.containers[*]",
+						Name:         ".name",
+						Env:          ".env",
+						VolumeMounts: ".volumeMounts",
+					},
+				},
+				Volumes: ".spec.jobTemplate.spec.template.spec.volumes",
+			},
+		},
+		{
+			name: "custom mapping with wildcard",
+			givenObjects: []client.Object{
+				&servicebindingv1alpha3.ClusterWorkloadResourceMapping{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cronjobs.batch",
+					},
+					Spec: servicebindingv1alpha3.ClusterWorkloadResourceMappingSpec{
+						Versions: []servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{
+							{
+								Version:     "*",
+								Annotations: ".spec.jobTemplate.spec.template.metadata.annotations",
+								Containers: []servicebindingv1alpha3.ClusterWorkloadResourceMappingContainer{
+									{
+										Path: ".spec.jobTemplate.spec.template.spec.initContainers[*]",
+										Name: ".name",
+									},
+									{
+										Path: ".spec.jobTemplate.spec.template.spec.containers[*]",
+										Name: ".name",
+									},
+								},
+								Volumes: ".spec.jobTemplate.spec.template.spec.volumes",
+							},
+						},
+					},
+				},
+			},
+			workload: &batchv1.CronJob{},
+			expected: &servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{
+				Version:     "*",
+				Annotations: ".spec.jobTemplate.spec.template.metadata.annotations",
+				Containers: []servicebindingv1alpha3.ClusterWorkloadResourceMappingContainer{
+					{
+						Path:         ".spec.jobTemplate.spec.template.spec.initContainers[*]",
+						Name:         ".name",
+						Env:          ".env",
+						VolumeMounts: ".volumeMounts",
+					},
+					{
+						Path:         ".spec.jobTemplate.spec.template.spec.containers[*]",
+						Name:         ".name",
+						Env:          ".env",
+						VolumeMounts: ".volumeMounts",
+					},
+				},
+				Volumes: ".spec.jobTemplate.spec.template.spec.volumes",
+			},
+		},
+		{
+			name: "default mapping is used when resource version is not defined, and no wildcard is defined",
+			givenObjects: []client.Object{
+				&servicebindingv1alpha3.ClusterWorkloadResourceMapping{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cronjobs.batch",
+					},
+					Spec: servicebindingv1alpha3.ClusterWorkloadResourceMappingSpec{
+						Versions: []servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{
+							{
+								Version:     "v1beta1", // the workload is version v1
+								Annotations: ".spec.jobTemplate.spec.template.metadata.annotations",
+								Containers: []servicebindingv1alpha3.ClusterWorkloadResourceMappingContainer{
+									{
+										Path: ".spec.jobTemplate.spec.template.spec.initContainers[*]",
+										Name: ".name",
+									},
+									{
+										Path: ".spec.jobTemplate.spec.template.spec.containers[*]",
+										Name: ".name",
+									},
+								},
+								Volumes: ".spec.jobTemplate.spec.template.spec.volumes",
+							},
+						},
+					},
+				},
+			},
+			workload: &batchv1.CronJob{},
+			expected: &servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{
+				Version: "*",
+				// default PodSpecable mapping, it won't actually work for a CronJob,
+				// but absent an explicit mapping, this is what's required.
+				Annotations: ".spec.template.metadata.annotations",
+				Containers: []servicebindingv1alpha3.ClusterWorkloadResourceMappingContainer{
+					{
+						Path:         ".spec.template.spec.initContainers[*]",
+						Name:         ".name",
+						Env:          ".env",
+						VolumeMounts: ".volumeMounts",
+					},
+					{
+						Path:         ".spec.template.spec.containers[*]",
+						Name:         ".name",
+						Env:          ".env",
+						VolumeMounts: ".volumeMounts",
+					},
+				},
+				Volumes: ".spec.template.spec.volumes",
+			},
+		},
+		{
+			name: "error if workload type not found in scheme",
+			givenObjects: []client.Object{
+				&servicebindingv1alpha3.ClusterWorkloadResourceMapping{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "myworkloads.workload.local",
+					},
+					Spec: servicebindingv1alpha3.ClusterWorkloadResourceMappingSpec{
+						Versions: []servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{
+							{
+								Version: "*",
+							},
+						},
+					},
+				},
+			},
+			// this is a bogus workload type, but it's sufficient for the test (we need a type object that is not registered with the scheme)
+			workload:    &networkingv1.Ingress{},
+			expectedErr: true,
+		},
+		{
+			name: "error if workload type not found in restmapper",
+			givenObjects: []client.Object{
+				&servicebindingv1alpha3.ClusterWorkloadResourceMapping{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "myworkloads.workload.local",
+					},
+					Spec: servicebindingv1alpha3.ClusterWorkloadResourceMappingSpec{
+						Versions: []servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate{
+							{
+								Version: "*",
+							},
+						},
+					},
+				},
+			},
+			workload: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "workload.local/v1",
+					"kind":       "MyWorkload",
+				},
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, c := range tests {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.TODO()
+
+			client := fakeclient.NewClientBuilder().
+				WithScheme(scheme).
+				WithRESTMapper(restMapper).
+				WithObjects(c.givenObjects...).
+				Build()
+			resolver := resolver.NewClusterResolver(client)
+
+			actual, err := resolver.LookupMapping(ctx, c.workload)
+
+			if (err != nil) != c.expectedErr {
+				t.Errorf("LookupMapping() expected err: %v", err)
+			}
+			if c.expectedErr {
+				return
+			}
+			if diff := cmp.Diff(c.expected, actual); diff != "" {
+				t.Errorf("LookupMapping() (-expected, +actual): %s", diff)
+			}
+		})
+	}
+}
+
+func TestClusterResolver_LookupBindingSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+
+	tests := []struct {
+		name         string
+		givenObjects []client.Object
+		serviceRef   corev1.ObjectReference
+		expected     string
+		expectedErr  bool
+	}{
+		{
+			name:         "direct binding",
+			givenObjects: []client.Object{},
+			serviceRef: corev1.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "Secret",
+				Namespace:  "my-namespace",
+				Name:       "my-secret",
+			},
+			expected: "my-secret",
+		},
+		{
+			name: "found provisioned service",
+			givenObjects: []client.Object{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "service.local/v1",
+						"kind":       "ProvisionedService",
+						"metadata": map[string]interface{}{
+							"namespace": "my-namespace",
+							"name":      "my-service",
+						},
+						"status": map[string]interface{}{
+							"binding": map[string]interface{}{
+								"name": "my-secret",
+							},
+						},
+					},
+				},
+			},
+			serviceRef: corev1.ObjectReference{
+				APIVersion: "service.local/v1",
+				Kind:       "ProvisionedService",
+				Namespace:  "my-namespace",
+				Name:       "my-service",
+			},
+			expected: "my-secret",
+		},
+		{
+			name: "found, but not a provisioned service",
+			givenObjects: []client.Object{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "service.local/v1",
+						"kind":       "NotAProvisionedService",
+						"metadata": map[string]interface{}{
+							"namespace": "my-namespace",
+							"name":      "my-service",
+						},
+						"status": map[string]interface{}{},
+					},
+				},
+			},
+			serviceRef: corev1.ObjectReference{
+				APIVersion: "service.local/v1",
+				Kind:       "NotAProvisionedService",
+				Namespace:  "my-namespace",
+				Name:       "my-service",
+			},
+			expected: "",
+		},
+		{
+			name:         "not found",
+			givenObjects: []client.Object{},
+			serviceRef: corev1.ObjectReference{
+				APIVersion: "service.local/v1",
+				Kind:       "ProvisionedService",
+				Namespace:  "my-namespace",
+				Name:       "my-service",
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, c := range tests {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.TODO()
+
+			client := fakeclient.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(c.givenObjects...).
+				Build()
+			resolver := resolver.NewClusterResolver(client)
+
+			actual, err := resolver.LookupBindingSecret(ctx, c.serviceRef)
+
+			if (err != nil) != c.expectedErr {
+				t.Errorf("LookupBindingSecret() expected err: %v", err)
+			}
+			if c.expectedErr {
+				return
+			}
+			if diff := cmp.Diff(c.expected, actual); diff != "" {
+				t.Errorf("LookupBindingSecret() (-expected, +actual): %s", diff)
+			}
+		})
+	}
+}
+
+func TestClusterResolver_LookupWorkload(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+
+	tests := []struct {
+		name         string
+		givenObjects []client.Object
+		serviceRef   corev1.ObjectReference
+		expected     client.Object
+		expectedErr  bool
+	}{
+		{
+			name:         "not found error",
+			givenObjects: []client.Object{},
+			serviceRef: corev1.ObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Namespace:  "my-namespace",
+				Name:       "my-workload",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "found workload from scheme",
+			givenObjects: []client.Object{
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-namespace",
+						Name:      "my-workload",
+					},
+				},
+			},
+			serviceRef: corev1.ObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Namespace:  "my-namespace",
+				Name:       "my-workload",
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"creationTimestamp": nil,
+						"name":              "my-workload",
+						"namespace":         "my-namespace",
+						"resourceVersion":   "999",
+					},
+					"spec": map[string]interface{}{
+						"selector": nil,
+						"strategy": map[string]interface{}{},
+						"template": map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"creationTimestamp": nil,
+							},
+							"spec": map[string]interface{}{
+								"containers": nil,
+							},
+						},
+					},
+					"status": map[string]interface{}{},
+				},
+			},
+		},
+		{
+			name: "found workload not from scheme",
+			givenObjects: []client.Object{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "workload.local/v1",
+						"kind":       "MyWorkload",
+						"metadata": map[string]interface{}{
+							"name":      "my-workload",
+							"namespace": "my-namespace",
+						},
+					},
+				},
+			},
+			serviceRef: corev1.ObjectReference{
+				APIVersion: "workload.local/v1",
+				Kind:       "MyWorkload",
+				Namespace:  "my-namespace",
+				Name:       "my-workload",
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "workload.local/v1",
+					"kind":       "MyWorkload",
+					"metadata": map[string]interface{}{
+						"name":            "my-workload",
+						"namespace":       "my-namespace",
+						"resourceVersion": "999",
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range tests {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.TODO()
+
+			client := fakeclient.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(c.givenObjects...).
+				Build()
+			resolver := resolver.NewClusterResolver(client)
+
+			actual, err := resolver.LookupWorkload(ctx, c.serviceRef)
+
+			if (err != nil) != c.expectedErr {
+				t.Errorf("LookupWorkload() expected err: %v", err)
+			}
+			if c.expectedErr {
+				return
+			}
+			if diff := cmp.Diff(c.expected, actual); diff != "" {
+				t.Errorf("LookupWorkload() (-expected, +actual): %s", diff)
+			}
+		})
+	}
+}

--- a/resolver/interface.go
+++ b/resolver/interface.go
@@ -21,14 +21,14 @@ import (
 
 	servicebindingv1alpha3 "github.com/servicebinding/service-binding-controller/apis/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type Resolver interface {
 	// LookupMapping returns the mapping template for the workload. Typically a ClusterWorkloadResourceMapping is defined for the workload's
 	// fully qualified resource `{resource}.{group}`. The workload's version is either directly matched, or the wildcard version `*`
 	// mapping template is returned. If no explicit mapping is found, a mapping appropriate for a PodSpecable resource may be used.
-	LookupMapping(ctx context.Context, workload client.Object) (*servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate, error)
+	LookupMapping(ctx context.Context, workload runtime.Object) (*servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate, error)
 
 	// LookupBindingSecret returns the binding secret name exposed by the service following the Provisioned Service duck-type
 	// (`.status.binding.name`). If a direction binding is used (where the referenced service is itself a Secret) the referenced Secret is
@@ -37,5 +37,5 @@ type Resolver interface {
 
 	// LookupWorkload returns the referenced object. Often a unstructured Object is used to sidestep issues with schemes and registered
 	// types.
-	LookupWorkload(ctx context.Context, workloadRef corev1.ObjectReference) (client.Object, error)
+	LookupWorkload(ctx context.Context, workloadRef corev1.ObjectReference) (runtime.Object, error)
 }

--- a/resolver/interface.go
+++ b/resolver/interface.go
@@ -14,25 +14,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package projector
+package resolver
 
 import (
 	"context"
 
 	servicebindingv1alpha3 "github.com/servicebinding/service-binding-controller/apis/v1alpha3"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type ServiceBindingProjector interface {
-	// Project the service into the workload as defined by the ServiceBinding.
-	Project(ctx context.Context, binding *servicebindingv1alpha3.ServiceBinding, workload client.Object) error
-	// Unproject the serice from the workload as defined by the ServiceBinding.
-	Unproject(ctx context.Context, binding *servicebindingv1alpha3.ServiceBinding, workload client.Object) error
-}
-
-type MappingSource interface {
-	// LookupMapping the mapping template for the workload. Typically a ClusterWorkloadResourceMapping is defined for the workload's
+type Resolver interface {
+	// LookupMapping returns the mapping template for the workload. Typically a ClusterWorkloadResourceMapping is defined for the workload's
 	// fully qualified resource `{resource}.{group}`. The workload's version is either directly matched, or the wildcard version `*`
 	// mapping template is returned. If no explicit mapping is found, a mapping appropriate for a PodSpecable resource may be used.
 	LookupMapping(ctx context.Context, workload client.Object) (*servicebindingv1alpha3.ClusterWorkloadResourceMappingTemplate, error)
+
+	// LookupBindingSecret returns the binding secret name exposed by the service following the Provisioned Service duck-type
+	// (`.status.binding.name`). If a direction binding is used (where the referenced service is itself a Secret) the referenced Secret is
+	// returned without a lookup.
+	LookupBindingSecret(ctx context.Context, serviceRef corev1.ObjectReference) (string, error)
+
+	// LookupWorkload returns the referenced object. Often a unstructured Object is used to sidestep issues with schemes and registered
+	// types.
+	LookupWorkload(ctx context.Context, workloadRef corev1.ObjectReference) (client.Object, error)
 }


### PR DESCRIPTION
There are three types of things that we need to be able to dynamically
resolve at runtime:
1. workloads
2. binding secrets (via services)
3. workload mappings

Each of is slightly more complicated than your standard client.Get call
as we need to work with dynamic types, and apply behavior from the spec.

The MappingSource previously in the projector, has moved into this new
package. The new Resolver interface is a superset of the projector's
desired MappingSource.

Resolves #33 