### PR TITLE
Allow .spec.name to be optional in validation

### DIFF
--- a/apis/v1beta1/servicebinding_webhook.go
+++ b/apis/v1beta1/servicebinding_webhook.go
@@ -44,12 +44,14 @@ var _ webhook.Validator = &ServiceBinding{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *ServiceBinding) ValidateCreate() error {
+	r.Default()
 	return r.validate().ToAggregate()
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *ServiceBinding) ValidateUpdate(old runtime.Object) error {
 	// TODO(user): check for immutable fields, if any
+	r.Default()
 	return r.validate().ToAggregate()
 }
 


### PR DESCRIPTION
As of the latest 1.0 specification, `.spec.name` is allowed to be optional.  To allow for this, remove the validation hooks that require this field to be set.

Signed-off-by: Andy Sadler <ansadler@redhat.com>