### PR TITLE
Validate workload selectors

### DIFF
--- a/apis/v1beta1/servicebinding_test.go
+++ b/apis/v1beta1/servicebinding_test.go
@@ -136,6 +136,39 @@ func TestServiceBindingValidate(t *testing.T) {
 			expected: field.ErrorList{},
 		},
 		{
+			name: "workload invalid selector",
+			seed: &ServiceBinding{
+				Spec: ServiceBindingSpec{
+					Name: "my-binding",
+					Service: ServiceBindingServiceReference{
+						APIVersion: "v1",
+						Kind:       "Secret",
+						Name:       "my-service",
+					},
+					Workload: ServiceBindingWorkloadReference{
+						APIVersion: "apps/v1",
+						Kind:       "Deloyment",
+						Selector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{{
+								Key:      "foo",
+								Operator: "NotAnOperator",
+								Values:   []string{"bar"},
+							}},
+						},
+					},
+				},
+			},
+			expected: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "workload", "selector"), &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{{
+						Key:      "foo",
+						Operator: "NotAnOperator",
+						Values:   []string{"bar"},
+					}},
+				}, `"NotAnOperator" is not a valid pod selector operator`),
+			},
+		},
+		{
 			name: "workload invalid overspeced",
 			seed: &ServiceBinding{
 				Spec: ServiceBindingSpec{

--- a/apis/v1beta1/servicebinding_webhook.go
+++ b/apis/v1beta1/servicebinding_webhook.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -113,6 +114,11 @@ func (r *ServiceBindingWorkloadReference) validate(fldPath *field.Path) field.Er
 	}
 	if r.Name != "" && r.Selector != nil {
 		errs = append(errs, field.Required(fldPath.Child("[name, selector]"), "expected exactly one, got both"))
+	}
+	if r.Selector != nil {
+		if _, err := metav1.LabelSelectorAsSelector(r.Selector); err != nil {
+			errs = append(errs, field.Invalid(fldPath.Child("selector"), r.Selector, err.Error()))
+		}
 	}
 
 	return errs


### PR DESCRIPTION
We should reject ServiceBindings with an invalid workload selector. This
will help us avoid issues at runtime when the invalid selector will
cause an error.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>