### PR TITLE
Show bound secret as a printer column

### DIFF
--- a/apis/v1beta1/servicebinding_types.go
+++ b/apis/v1beta1/servicebinding_types.go
@@ -103,6 +103,7 @@ type ServiceBindingStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Secret",type=string,JSONPath=`.status.binding.name`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`

--- a/config/crd/bases/servicebinding.io_servicebindings.yaml
+++ b/config/crd/bases/servicebinding.io_servicebindings.yaml
@@ -260,6 +260,9 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
+    - jsonPath: .status.binding.name
+      name: Secret
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string


### PR DESCRIPTION
```
kubectl get servicebinding
```

```
NAME                  SECRET                READY   REASON         AGE
spring-petclinic-db   spring-petclinic-db   True    ServiceBound   20m
```

Signed-off-by: Scott Andrews <andrewssc@vmware.com>